### PR TITLE
Update error message if unable to connect to GrowthBook instance

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GrowthBook DevTools",
   "description": "QA and debug feature flags and experiments from GrowthBook's js/react SDKs",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "manifest_version": 3,
   "devtools_page": "devtools.html",
   "permissions": ["activeTab"],

--- a/src/chromeServices/page.ts
+++ b/src/chromeServices/page.ts
@@ -28,7 +28,8 @@ function onGrowthBookLoad(cb: (gb: GrowthBook) => void) {
   let timer = window.setTimeout(() => {
     const msg: ErrorMessage = {
       type: "GB_ERROR",
-      error: "Timed out waiting for GrowthBook SDK instance",
+      error:
+        "Unable to locate GrowthBook SDK instance. Please ensure you are using either the Javascript or React SDK, and Dev Mode is enabled.",
     };
     window.postMessage(msg, "*");
   }, 5000);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,6 @@ import {
   Alert,
   AlertDescription,
   AlertIcon,
-  AlertTitle,
 } from "@chakra-ui/alert";
 import { Box, Text } from "@chakra-ui/layout";
 import { Spinner } from "@chakra-ui/spinner";
@@ -35,7 +34,6 @@ function WaitForGrowthBook() {
           <Box>
             <Alert status="error">
               <AlertIcon />
-              <AlertTitle mr={2}>Error</AlertTitle>
               <AlertDescription>{error}</AlertDescription>
             </Alert>
             <Box mt={3} textAlign="center">


### PR DESCRIPTION
### Features & Changes

In this PR - https://github.com/growthbook/growthbook/pull/616 we are deprecating support for `disableDevTools` and instead, making it to where users have to opt-in to the Dev Tools via `enableDevTools`. This PR updates the error message if the Dev Tools extension is not able to connect to the GrowthBook instance, to provide more context to the user as to how to remedy the issue.

Updated error message.
<img width="510" alt="Screen Shot 2022-10-12 at 1 38 54 PM" src="https://user-images.githubusercontent.com/75274610/195411068-cb450c96-13d1-4bbd-880d-7e41b4a7babb.png">
