### PR TITLE
Visual editor 2.0 - Fast follow fixes

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,7 +12,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["js/vendor.js", "js/content_script.js"]
+      "js": ["js/content_script.js"]
     }
   ],
 

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import * as ReactDOM from "react-dom/client";
 import { useApiKey } from "../utils/hooks";
 import ApiKeyForm from "./ApiKeyForm";

--- a/src/visual_editor/DOMMutationList.tsx
+++ b/src/visual_editor/DOMMutationList.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, useCallback } from "react";
 import { DeclarativeMutation } from "dom-mutator";
 import { FC } from "react";
 import { RxCross2 } from "react-icons/rx";
@@ -16,7 +16,13 @@ const DOMMutationList: FC<{
   globalCss?: string;
   mutations: DeclarativeMutation[];
   removeDomMutation?: (mutationIndex: number) => void;
-}> = ({ mutations: _mutations, removeDomMutation, globalCss }) => {
+  clearGlobalCss?: () => void;
+}> = ({
+  mutations: _mutations,
+  removeDomMutation,
+  globalCss,
+  clearGlobalCss,
+}) => {
   const mutations: DeclarativeMutation[] = [
     ...(globalCss
       ? [
@@ -30,6 +36,17 @@ const DOMMutationList: FC<{
       : []),
     ..._mutations,
   ];
+
+  const onRemoveMutation = useCallback(
+    (mutation: DeclarativeMutation) => {
+      if (mutation.selector === "global" && mutation.attribute === "css") {
+        clearGlobalCss?.();
+        return;
+      }
+      removeDomMutation?.(mutations.indexOf(mutation));
+    },
+    [removeDomMutation, clearGlobalCss]
+  );
 
   if (!mutations.length) return null;
 
@@ -51,7 +68,7 @@ const DOMMutationList: FC<{
             <div className="w-8 flex justify-end">
               <RxCross2
                 className="w-4 h-4 cursor-pointer hover:text-slate-100"
-                onClick={() => removeDomMutation(index)}
+                onClick={() => onRemoveMutation(mutation)}
               />
             </div>
           )}

--- a/src/visual_editor/ElementDetails/AttributeEdit.tsx
+++ b/src/visual_editor/ElementDetails/AttributeEdit.tsx
@@ -50,7 +50,7 @@ const EditAttributeInput: FC<{
     _onCancel();
   }, [setName, setValue]);
   const onSubmit = useCallback(() => {
-    _onSubmit({ name, value });
+    _onSubmit({ name, value: value.trim() });
     onCancel();
   }, [name, value, _onSubmit, onCancel]);
   return (
@@ -70,7 +70,7 @@ const EditAttributeInput: FC<{
       <TextareaAutosize
         className="py-0 px-2 text-sm text-black mr-2 mb-1"
         placeholder="Value"
-        value={value?.trim()}
+        value={value}
         onChange={(e) => setValue(e.target.value)}
       />
 

--- a/src/visual_editor/GlobalCSSEditor.tsx
+++ b/src/visual_editor/GlobalCSSEditor.tsx
@@ -1,9 +1,13 @@
-import React, { FC } from "react";
+import React, { FC, useEffect, useState } from "react";
 
 const GlobalCSSEditor: FC<{
   css?: string;
-  setCss: (css: string) => void;
-}> = ({ css = "", setCss }) => {
+  onSubmit: (css: string) => void;
+}> = ({ css: _css = "", onSubmit }) => {
+  const [css, setCss] = useState(_css);
+
+  useEffect(() => onSubmit(css), [css]);
+
   return (
     <div className="px-4 pb-4">
       <textarea

--- a/src/visual_editor/Toolbar/index.tsx
+++ b/src/visual_editor/Toolbar/index.tsx
@@ -30,11 +30,13 @@ const modeToIcon: Record<ToolbarMode, IconType> = {
 const ToolbarButton = ({
   mode,
   enable,
+  disable = () => {},
   isActive,
   title,
 }: {
   mode: ToolbarMode;
   enable: () => void;
+  disable?: () => void;
   isActive: boolean;
   title: string;
 }) => {
@@ -48,7 +50,7 @@ const ToolbarButton = ({
           "bg-slate-700": isActive,
         }
       )}
-      onClick={enable}
+      onClick={isActive ? disable : enable}
     >
       <Icon />
     </button>
@@ -74,6 +76,8 @@ const Toolbar: FC<{
           mode="selection"
           enable={() => {
             setMode("selection");
+          }}
+          disable={() => {
             clearSelectedElement();
           }}
           title="Selection mode"

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -225,7 +225,7 @@ const VisualEditor: FC<{}> = () => {
     debounce((css: string) => {
       updateSelectedVariation({ css });
       globalStyleTag.innerHTML = css;
-    }, 1000),
+    }, 500),
     [updateSelectedVariation]
   );
 
@@ -561,6 +561,7 @@ const VisualEditor: FC<{}> = () => {
         >
           <DOMMutationList
             globalCss={selectedVariation.css}
+            clearGlobalCss={() => setGlobalCSS("")}
             removeDomMutation={removeDomMutation}
             mutations={selectedVariation?.domMutations ?? []}
           />

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -222,10 +222,10 @@ const VisualEditor: FC<{}> = () => {
   );
 
   const setGlobalCSS = useCallback(
-    (css: string) => {
+    debounce((css: string) => {
       updateSelectedVariation({ css });
       globalStyleTag.innerHTML = css;
-    },
+    }, 1000),
     [updateSelectedVariation]
   );
 
@@ -531,7 +531,10 @@ const VisualEditor: FC<{}> = () => {
 
       {mode === "css" && (
         <VisualEditorSection title="Global CSS">
-          <GlobalCSSEditor css={selectedVariation.css} setCss={setGlobalCSS} />
+          <GlobalCSSEditor
+            css={selectedVariation.css}
+            onSubmit={setGlobalCSS}
+          />
         </VisualEditorSection>
       )}
 

--- a/src/visual_editor/lib/selectionMode.ts
+++ b/src/visual_editor/lib/selectionMode.ts
@@ -33,7 +33,7 @@ let _selectedElement: HTMLElement | null;
 let _setSelectedElement: ((element: HTMLElement | null) => void) | null;
 let _setHighlightedElementSelector: ((selector: string) => void) | null;
 
-const clickHandler = (event: MouseEvent) => {
+const mouseDownHandler = (event: MouseEvent) => {
   // don't intercept cilcks on the visual editor itself
   if ((event.target as HTMLElement).id === CONTAINER_ID) return;
 
@@ -51,7 +51,7 @@ const teardown = () => {
   clearHighlightedElementAttr();
   clearSelectedElementAttr();
   document.removeEventListener("mousemove", mouseMoveHandler);
-  document.removeEventListener("click", clickHandler, true);
+  document.removeEventListener("mousedown", mouseDownHandler);
 };
 
 export const updateSelectedElement = ({
@@ -94,7 +94,7 @@ export const toggleSelectionMode = ({
     _setSelectedElement = setSelectedElement;
     _setHighlightedElementSelector = setHighlightedElementSelector;
     document.addEventListener("mousemove", mouseMoveHandler);
-    document.addEventListener("click", clickHandler, true);
+    document.addEventListener("mousedown", mouseDownHandler);
   } else {
     teardown();
   }

--- a/webpack/webpack.devtools.js
+++ b/webpack/webpack.devtools.js
@@ -18,9 +18,6 @@ module.exports = {
     nodeEnv: "development",
     splitChunks: {
       name: "vendor",
-      chunks(chunk) {
-        return chunk.name !== "background" && chunk.name !== "visual_editor";
-      },
     },
   },
   module: {

--- a/webpack/webpack.visual-editor.js
+++ b/webpack/webpack.visual-editor.js
@@ -14,14 +14,6 @@ module.exports = {
     filename: "[name].js",
     assetModuleFilename: "[name][ext]",
   },
-  optimization: {
-    splitChunks: {
-      name: "vendor",
-      chunks(chunk) {
-        return chunk.name !== "background" && chunk.name !== "visual_editor";
-      },
-    },
-  },
   module: {
     rules: [
       {


### PR DESCRIPTION
Changes:
- Switch from `click` to `mousedown` for select element click event
- Debounce Global CSS editing / saving
- Keep element selected when switching between modes
- Fix buggy trimming logic for attribute editing