### PR TITLE
Visual editor - Fast follow 02

### DIFF
--- a/src/visual_editor/DOMMutationList.tsx
+++ b/src/visual_editor/DOMMutationList.tsx
@@ -15,7 +15,7 @@ const DOMAttrColumn: FC<{ children: ReactNode }> = ({ children }) => (
 const DOMMutationList: FC<{
   globalCss?: string;
   mutations: DeclarativeMutation[];
-  removeDomMutation?: (mutationIndex: number) => void;
+  removeDomMutation?: (mutation: DeclarativeMutation) => void;
   clearGlobalCss?: () => void;
 }> = ({
   mutations: _mutations,
@@ -43,7 +43,7 @@ const DOMMutationList: FC<{
         clearGlobalCss?.();
         return;
       }
-      removeDomMutation?.(mutations.indexOf(mutation));
+      removeDomMutation?.(mutation);
     },
     [removeDomMutation, clearGlobalCss]
   );

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -273,10 +273,11 @@ const VisualEditor: FC<{}> = () => {
   );
 
   const removeDomMutation = useCallback(
-    (domMutationIndex: number) => {
+    (mutation: DeclarativeMutation) => {
+      const indexToDelete = selectedVariation.domMutations.indexOf(mutation);
       updateSelectedVariation({
         domMutations: selectedVariation.domMutations.filter(
-          (_mutation, i) => i !== domMutationIndex
+          (_mutation, i) => i !== indexToDelete
         ),
       });
     },
@@ -549,7 +550,10 @@ const VisualEditor: FC<{}> = () => {
           isCollapsible
           title={`Changes (${selectedElementMutations.length})`}
         >
-          <DOMMutationList mutations={selectedElementMutations ?? []} />
+          <DOMMutationList
+            mutations={selectedElementMutations ?? []}
+            removeDomMutation={removeDomMutation}
+          />
         </VisualEditorSection>
       )}
 

--- a/src/visual_editor/lib/selectionMode.ts
+++ b/src/visual_editor/lib/selectionMode.ts
@@ -33,6 +33,13 @@ let _selectedElement: HTMLElement | null;
 let _setSelectedElement: ((element: HTMLElement | null) => void) | null;
 let _setHighlightedElementSelector: ((selector: string) => void) | null;
 
+// only the 'click' event can prevent the default behavior when clicking on
+// a link or button or similar
+const clickHandler = (event: MouseEvent) => {
+  event.preventDefault();
+  event.stopPropagation();
+};
+
 const mouseDownHandler = (event: MouseEvent) => {
   // don't intercept cilcks on the visual editor itself
   if ((event.target as HTMLElement).id === CONTAINER_ID) return;
@@ -52,6 +59,7 @@ const teardown = () => {
   clearSelectedElementAttr();
   document.removeEventListener("mousemove", mouseMoveHandler);
   document.removeEventListener("mousedown", mouseDownHandler);
+  document.removeEventListener("click", clickHandler);
 };
 
 export const updateSelectedElement = ({
@@ -95,6 +103,7 @@ export const toggleSelectionMode = ({
     _setHighlightedElementSelector = setHighlightedElementSelector;
     document.addEventListener("mousemove", mouseMoveHandler);
     document.addEventListener("mousedown", mouseDownHandler);
+    document.addEventListener("click", clickHandler);
   } else {
     teardown();
   }


### PR DESCRIPTION
Changes:
- Reinstate `click` event to block mouse clicks on links (continue using mousedown for selection only)
- Allow deleting DOM changes from selection tab