### PR TITLE
Add query param check

### DIFF
--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -1,5 +1,10 @@
 import type { Message } from "../devtools";
 import {
+  VISUAL_CHANGESET_ID_PARAMS_KEY,
+  EXPERIMENT_URL_PARAMS_KEY,
+  API_HOST_PARAMS_KEY,
+} from "./visual_editor/lib/constants";
+import {
   loadApiHost,
   loadApiKey,
   saveApiHost,
@@ -69,7 +74,11 @@ if (!document.getElementById(DEVTOOLS_SCRIPT_ID)) {
 
 const hasVisualEditorQueryParams = () => {
   const urlParams = new URLSearchParams(window.location.search);
-  return !!urlParams.get("vc-id");
+  return (
+    !!urlParams.get(VISUAL_CHANGESET_ID_PARAMS_KEY) &&
+    !!urlParams.get(EXPERIMENT_URL_PARAMS_KEY) &&
+    !!urlParams.get(API_HOST_PARAMS_KEY)
+  );
 };
 
 // Inject visual editor content script

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -67,9 +67,17 @@ if (!document.getElementById(DEVTOOLS_SCRIPT_ID)) {
   document.body.appendChild(script);
 }
 
+const hasVisualEditorQueryParams = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  return !!urlParams.get("vc-id");
+};
+
 // Inject visual editor content script
 const VISUAL_EDITOR_SCRIPT_ID = "visual-editor-script";
-if (!document.getElementById(VISUAL_EDITOR_SCRIPT_ID)) {
+if (
+  !document.getElementById(VISUAL_EDITOR_SCRIPT_ID) &&
+  hasVisualEditorQueryParams()
+) {
   const script = document.createElement("script");
   script.id = VISUAL_EDITOR_SCRIPT_ID;
   script.async = true;

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -50,11 +50,12 @@ import AttributeEdit, {
 import SetApiCredsForm from "./SetApiCredsForm";
 import useMessage from "./lib/hooks/useMessage";
 import { ApiCreds } from "../../devtools";
-
-const VISUAL_CHANGESET_ID_PARAMS_KEY = "vc-id";
-const VARIATION_INDEX_PARAMS_KEY = "v-idx";
-const EXPERIMENT_URL_PARAMS_KEY = "exp-url";
-const API_HOST_PARAMS_KEY = "api-host";
+import {
+  VISUAL_CHANGESET_ID_PARAMS_KEY,
+  VARIATION_INDEX_PARAMS_KEY,
+  EXPERIMENT_URL_PARAMS_KEY,
+  API_HOST_PARAMS_KEY,
+} from "./lib/constants";
 
 export interface VisualEditorVariation {
   name: string;

--- a/src/visual_editor/lib/constants.ts
+++ b/src/visual_editor/lib/constants.ts
@@ -1,0 +1,4 @@
+export const VISUAL_CHANGESET_ID_PARAMS_KEY = "vc-id";
+export const VARIATION_INDEX_PARAMS_KEY = "v-idx";
+export const EXPERIMENT_URL_PARAMS_KEY = "exp-url";
+export const API_HOST_PARAMS_KEY = "api-host";


### PR DESCRIPTION
The Visual Editor is currently being injected on all pages for browsers with the chrome extension installed. This is executing a lot of React code behind the scenes even if the user is not using the visual editor at all.

This PR adds a check to only mount the React app when the necessary query params (`vc-id`) are in the URL

Before:

<img width="1587" alt="image" src="https://user-images.githubusercontent.com/2374625/229628326-cff5cd7e-160d-445b-9e96-ddc3243f403e.png">

After refresh w/ changes:

<img width="1587" alt="image" src="https://user-images.githubusercontent.com/2374625/229628414-ed749862-eb1e-461e-9280-63dc358c9d60.png">
