### PR TITLE
Pass along error messages from network

### DIFF
--- a/src/visual_editor/lib/hooks/useApi.ts
+++ b/src/visual_editor/lib/hooks/useApi.ts
@@ -89,9 +89,10 @@ const useApi: UseApiHook = ({ apiKey, apiHost }: Partial<ApiCreds>) => {
           }
         );
 
-        if (response.status !== 200) throw new Error(response.statusText);
-
         const res = await response.json();
+
+        if (response.status !== 200)
+          throw new Error(res?.message || response.statusText);
 
         const { visualChangeset, experiment } = res;
 
@@ -101,9 +102,11 @@ const useApi: UseApiHook = ({ apiKey, apiHost }: Partial<ApiCreds>) => {
           visualChangeset,
           experiment,
         };
-      } catch (e) {
+      } catch (e: any) {
         setError(
-          "There was an error reaching the API. Please check your API key and host."
+          `There was an error reaching the API. ${
+            e || "Please check your API key and host."
+          }`
         );
         return {};
       }


### PR DESCRIPTION
Prior to this change, we were only reporting a generic 'Please check your API Key and host' message for *any* error that occurred when establishing connection between the visual editor and growthbook API.

Now we are relaying the error message generated by the network request which should be more helpful in troubleshooting

**Matt's query params issue from earlier** (now reports error specific to api-host query param)
<img width="399" alt="Screenshot 2023-06-20 at 1 43 59 PM" src="https://github.com/growthbook/devtools/assets/2374625/323a2294-6997-4697-8d24-38a8dcfd21b2">

**Wrong hostname error** ('failed to fetch')
<img width="402" alt="Screenshot 2023-06-20 at 1 43 52 PM" src="https://github.com/growthbook/devtools/assets/2374625/22c87ef3-6ae6-4c29-87a5-23e8f21f919e">
