### PR TITLE
Upgrade @growthbook/growthbook

### DIFF
--- a/.github/scripts/check-pkg-version.js
+++ b/.github/scripts/check-pkg-version.js
@@ -1,0 +1,22 @@
+const fs = require("fs");
+
+async function checkVersion() {
+  const packageName = "@growthbook/growthbook"; // Replace this with the package name you want to check
+  const packageJson = JSON.parse(fs.readFileSync("package.json"));
+  const localVersion =
+    packageJson.dependencies[packageName] ||
+    packageJson.devDependencies[packageName];
+
+  const response = await fetch(`https://registry.npmjs.org/${packageName}`);
+  const data = await response.json();
+  const latestVersion = data["dist-tags"].latest;
+
+  if (localVersion !== latestVersion) {
+    console.error(
+      `The local version ${localVersion} is not the latest version ${latestVersion}.`
+    );
+    process.exit(1);
+  }
+}
+
+checkVersion();

--- a/.github/scripts/check-pkg-version.js
+++ b/.github/scripts/check-pkg-version.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const fetch = require("node-fetch");
 
 async function checkVersion() {
   const packageName = "@growthbook/growthbook"; // Replace this with the package name you want to check

--- a/.github/scripts/check-pkg-version.js
+++ b/.github/scripts/check-pkg-version.js
@@ -15,7 +15,7 @@ async function checkVersion() {
 
   if (localVersion !== latestVersion) {
     console.error(
-      `The local version ${localVersion} is not the latest version ${latestVersion}.`
+      `The local version of @growthbook/growthbook (${localVersion}) is not the latest version ${latestVersion}.`
     );
     process.exit(1);
   }

--- a/.github/scripts/check-pkg-version.js
+++ b/.github/scripts/check-pkg-version.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
-const fetch = require("node-fetch");
+const fetch = (...args) =>
+  import("node-fetch").then(({ default: fetch }) => fetch(...args));
 
 async function checkVersion() {
   const packageName = "@growthbook/growthbook"; // Replace this with the package name you want to check

--- a/.github/scripts/check-pkg-version.js
+++ b/.github/scripts/check-pkg-version.js
@@ -11,7 +11,7 @@ async function checkVersion() {
   const data = await response.json();
   const latestVersion = data["dist-tags"].latest;
 
-  if (localVersion !== latestVersion) {
+  if (localVersion.replace(/\^/, "") !== latestVersion) {
     console.error(
       `The local version of @growthbook/growthbook (${localVersion}) is not the latest version ${latestVersion}.`
     );

--- a/.github/scripts/check-pkg-version.js
+++ b/.github/scripts/check-pkg-version.js
@@ -5,9 +5,7 @@ const fetch = (...args) =>
 async function checkVersion() {
   const packageName = "@growthbook/growthbook"; // Replace this with the package name you want to check
   const packageJson = JSON.parse(fs.readFileSync("package.json"));
-  const localVersion =
-    packageJson.dependencies[packageName] ||
-    packageJson.devDependencies[packageName];
+  const localVersion = packageJson.dependencies[packageName];
 
   const response = await fetch(`https://registry.npmjs.org/${packageName}`);
   const data = await response.json();

--- a/.github/workflows/check-pkg-version.yml
+++ b/.github/workflows/check-pkg-version.yml
@@ -1,4 +1,4 @@
-name: Check Package Version
+name: Check Growthbook SDK version is latest
 
 on:
   pull_request:

--- a/.github/workflows/check-pkg-version.yml
+++ b/.github/workflows/check-pkg-version.yml
@@ -3,6 +3,7 @@ name: Check Package Version
 on:
   pull_request:
     paths:
+      - 'src/**/*.ts'
       - 'package.json'
 
 jobs:

--- a/.github/workflows/check-pkg-version.yml
+++ b/.github/workflows/check-pkg-version.yml
@@ -1,0 +1,30 @@
+name: Check Package Version
+
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Check package version
+        run: node .github/scripts/check-pkg-version.js
+
+      - name: Alert on failure
+        if: ${{ failure() }}
+        run: echo "@growthbook/growthbook not up-to-date with what is published on npm."
+

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@chakra-ui/react": "^2.4.9",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@growthbook/growthbook": "^0.20.1",
+    "@growthbook/growthbook": "^0.28.0",
     "@medv/finder": "^2.1.0",
     "clsx": "^1.2.1",
     "dom-mutator": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "css-loader": "^6.7.3",
     "glob": "^7.1.6",
     "jest": "^27.2.1",
+    "node-fetch": "^3.3.2",
     "postcss": "^8.4.21",
     "postcss-loader": "^7.0.2",
     "prettier": "^2.2.1",

--- a/src/background.ts
+++ b/src/background.ts
@@ -280,6 +280,8 @@ chrome.runtime.onMessage.addListener(
     const { type, data } = message;
     const senderOrigin = sender.origin;
 
+    consle.log("debug");
+
     switch (type) {
       case "BG_LOAD_VISUAL_CHANGESET":
         fetchVisualChangeset(data).then((res) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -280,7 +280,7 @@ chrome.runtime.onMessage.addListener(
     const { type, data } = message;
     const senderOrigin = sender.origin;
 
-    consle.log("debug");
+    console.log("debug");
 
     switch (type) {
       case "BG_LOAD_VISUAL_CHANGESET":

--- a/src/background.ts
+++ b/src/background.ts
@@ -280,8 +280,6 @@ chrome.runtime.onMessage.addListener(
     const { type, data } = message;
     const senderOrigin = sender.origin;
 
-    console.log("debug");
-
     switch (type) {
       case "BG_LOAD_VISUAL_CHANGESET":
         fetchVisualChangeset(data).then((res) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3978,7 +3978,7 @@ node-domexception@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
-node-fetch@^3.2.0:
+node-fetch@^3.2.0, node-fetch@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
   integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1212,10 +1212,12 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
   integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
-"@growthbook/growthbook@^0.20.1":
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-0.20.1.tgz#86f54f034ab0d8121f5b5b75ad8d883974b5327b"
-  integrity sha512-frNwdN99jr6NUNWJC5YKA+cmbPaTJsGac3rYRbvihx3xLgM3IbphhNQe+791f0xr/RpRcGCp2vUsyCcM+TduMw==
+"@growthbook/growthbook@^0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-0.28.0.tgz#c6cf7d46aa7465be120ed98c05adba01fdf4635c"
+  integrity sha512-RnrP29yHfL12nmAxtPbyHlY70BSB2f/LIOrYaBhqn2oBNdeuAxwGt9FO40dDJh0W+opaG5EbiPvZUxsy8J0aAw==
+  dependencies:
+    dom-mutator "^0.5.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"


### PR DESCRIPTION
Fixes [#1664](https://github.com/growthbook/growthbook/issues/1664)

The JS SDK in devtools was out of date by several versions. Only recently have regressions started coming up (as noted in above linked issue). This PR 1) adds a CI job to catch when `@growthbook/growthbook` is out-of-date and 2) upgrades said package to latest

Caveats - The opening of a pull request isn't the most ideal time to check whether our SDK is out of date - it's best to check before publishing the extension. However having a CI job check for this the quickest way to have a forcing function somewhere in the lifecycle to ensure we stay up to date. No doubt if this CI check was there prior we would have caught this much earlier.

Changes:
- Adds a script and a github workflow to run said script upon any pull request that includes changes to `src/**/*.ts` 
- Upgrades `@growthbook/growthbook` to 0.28.0

CI Job successfully failing:
<img width="1582" alt="Screenshot 2023-09-12 at 8 28 55 PM" src="https://github.com/growthbook/devtools/assets/2374625/ab0f7d51-e908-4c92-9f5d-5fe236cf3c97">

