### PR TITLE
Send message to specific tab being inspected

### DIFF
--- a/src/devtools/controller.ts
+++ b/src/devtools/controller.ts
@@ -4,6 +4,7 @@ import {
   RefreshMessage,
   SetOverridesMessage,
 } from "../../devtools";
+import MessageSender = chrome.runtime.MessageSender;
 
 // Send message to content script
 function sendMessage(msg: Message) {
@@ -26,7 +27,11 @@ export function onGrowthBookData(
 }
 
 chrome.runtime.onMessage.addListener(
-  async (msg: RefreshMessage | ErrorMessage) => {
+  async (msg: RefreshMessage | ErrorMessage, sender: MessageSender) => {
+    if (sender.tab?.id !== chrome.devtools?.inspectedWindow?.tabId) {
+      return;
+    }
+
     if (msg.type === "GB_REFRESH") {
       refreshListeners.forEach((cb) => {
         cb("", msg);

--- a/src/devtools/controller.ts
+++ b/src/devtools/controller.ts
@@ -7,16 +7,10 @@ import {
 
 // Send message to content script
 function sendMessage(msg: Message) {
-  chrome.tabs &&
-    chrome.tabs.query(
-      {
-        active: true,
-        currentWindow: true,
-      },
-      (tabs) => {
-        chrome.tabs.sendMessage(tabs[0].id || 0, msg);
-      }
-    );
+  if (chrome.tabs && chrome.devtools?.inspectedWindow) {
+    const  { tabId } = chrome.devtools.inspectedWindow;
+    chrome.tabs.sendMessage(tabId || 0, msg);
+  }
 }
 
 // Listen for updates from content script and forward to any listeners


### PR DESCRIPTION
This change sends a message to the specific tab being inspected by the Chrome devtools currently being used.

fixes #42, fixes #39 