### PR TITLE
Devtools - Fix experiments debug log for url targeting

### DIFF
--- a/devtools.d.ts
+++ b/devtools.d.ts
@@ -92,6 +92,7 @@ export type RefreshMessage = {
   experiments: Record<string, Experiment<any>>;
   attributes: Record<string, any>;
   overrides: Record<string, ExperimentOverride>;
+  url: string;
 };
 
 export type ErrorMessage = {

--- a/src/devtools/embed_script.ts
+++ b/src/devtools/embed_script.ts
@@ -56,6 +56,7 @@ function getRefreshMessage(gb: GrowthBook): RefreshMessage {
     features: gb.getFeatures(),
     overrides: (gb as any).context?.overrides || {},
     experiments,
+    url: window.location.href,
   };
 
   return msg;

--- a/src/devtools/ui/App.tsx
+++ b/src/devtools/ui/App.tsx
@@ -23,6 +23,7 @@ export interface Props {
   features: Record<string, FeatureDefinition>;
   experiments: Record<string, ExperimentInterface<any>>;
   attributes: Record<string, any>;
+  url: string;
 }
 
 function App(props: Props) {
@@ -49,11 +50,12 @@ function App(props: Props) {
   const { features, experiments, attributes } = useMemo(() => {
     const forcedFeatureMap = new Map(Object.entries(forcedFeatureValues));
 
-    const { features, experiments, attributes, overrides } = props;
+    const { features, experiments, attributes, overrides, url } = props;
 
     // Local GrowthBook instance for debugging
     let log: DebugLogs = [];
     const growthbook = new GrowthBook({
+      url,
       attributes,
       features,
       overrides,

--- a/src/devtools/ui/Experiment.tsx
+++ b/src/devtools/ui/Experiment.tsx
@@ -103,6 +103,7 @@ export default function Experiment({
                   const color = COLORS[i % COLORS.length];
                   return (
                     <Box
+                      key={i}
                       bg={`${color}.500`}
                       overflowX="hidden"
                       h="18px"

--- a/src/devtools/ui/index.tsx
+++ b/src/devtools/ui/index.tsx
@@ -57,6 +57,7 @@ function WaitForGrowthBook() {
 
   return (
     <App
+      url={data.url}
       features={data.features}
       experiments={data.experiments}
       attributes={data.attributes}

--- a/src/visual_editor/lib/hooks/useSDKDiagnostics.ts
+++ b/src/visual_editor/lib/hooks/useSDKDiagnostics.ts
@@ -19,20 +19,13 @@ const useSDKDiagnostics: UseSDKDiagnosticsHook = () => {
 
   useEffect(() => {
     if (!window) return;
-    const onLoad = () => {
-      setSDKStatus({
-        hasSDK: !!window._growthbook,
-        hasLatest: window._growthbook?.version === LATEST_SDK_VERSION,
-      });
-
-      if (window._growthbook?.version)
-        setVersion(window._growthbook?.version || "");
-    };
-    window.addEventListener("load", onLoad);
-    return () => {
-      window.removeEventListener("load", onLoad);
-    };
-  }, []);
+    setSDKStatus({
+      hasSDK: !!window._growthbook,
+      hasLatest: window._growthbook?.version === LATEST_SDK_VERSION,
+    });
+    if (window._growthbook?.version)
+      setVersion(window._growthbook?.version || "");
+  }, [setSDKStatus]);
 
   return {
     hasSDK,


### PR DESCRIPTION
From slack:
> A user found a bug in the devtools panel when looking at visual editor experiments.  When we sync the page's GrowthBook instance to devtools, we're not passing the URL, so if you look at a visual editor experiment, it always fails targeting rules.