### PR TITLE
2.6 Touch ups - Add check for hash attribute; Add tooltip; Refine tooltip styling

### DIFF
--- a/devtools.d.ts
+++ b/devtools.d.ts
@@ -37,6 +37,7 @@ export interface VisualEditorVariation {
 
 export interface APIExperiment {
   id: string;
+  hashAttribute: string;
   variations: {
     variationId: string;
     key: string;

--- a/src/visual_editor/components/DebugPanel.tsx
+++ b/src/visual_editor/components/DebugPanel.tsx
@@ -17,16 +17,21 @@ const GreenCheck = () => (
 const RedX = () => (
   <IoMdCloseCircle className="gb-text-red-400 gb-w-4 gb-h-4 gb-inline" />
 );
+
 export default function DebugPanel({
   experiment,
   visualChangeset,
   hasSDK,
   sdkVersion,
+  hashAttribute,
+  hasHashAttribute,
 }: {
   experiment: APIExperiment | null;
   visualChangeset: APIVisualChangeset | null;
   hasSDK: boolean;
   sdkVersion: string;
+  hashAttribute: string;
+  hasHashAttribute: boolean;
 }) {
   return (
     <div className="gb-text-light gb-px-4 gb-text-sm">
@@ -34,6 +39,30 @@ export default function DebugPanel({
         Experiment ID:{" "}
         <div className="gb-text-white">
           {experiment ? experiment.id : "N/A"}
+        </div>
+      </Row>
+
+      <Row>
+        Hash Attribute:{" "}
+        <div className="gb-text-white">
+          <ul className="gb-ml-4 gb-list-disc">
+            <li>
+              <code className="gb-text-xs gb-inline-block gb-max-w-full gb-whitespace-nowrap gb-text-ellipsis gb-overflow-hidden gb-bg-white gb-text-red-600 gb-rounded gb-px-1">
+                {hashAttribute ? hashAttribute : ""}
+              </code>
+            </li>
+            <li>
+              {hasHashAttribute ? (
+                <>
+                  <GreenCheck /> Attribute is set
+                </>
+              ) : (
+                <>
+                  <RedX /> Attribute is not set
+                </>
+              )}
+            </li>
+          </ul>
         </div>
       </Row>
 
@@ -69,7 +98,7 @@ export default function DebugPanel({
         {visualChangeset?.urlPatterns.map((pattern, i) => (
           <div key={i} className="gb-my-2 gb-text-white">
             <Tooltip label={pattern.pattern}>
-              <code className="gb-text-xs gb-block gb-w-full gb-whitespace-nowrap gb-text-ellipsis gb-overflow-hidden gb-bg-white gb-text-red-600 gb-rounded gb-px-1">
+              <code className="gb-text-xs gb-inline-block gb-max-w-full gb-whitespace-nowrap gb-text-ellipsis gb-overflow-hidden gb-bg-white gb-text-red-600 gb-rounded gb-px-1">
                 {pattern.pattern}
               </code>
             </Tooltip>

--- a/src/visual_editor/components/DebugPanel.tsx
+++ b/src/visual_editor/components/DebugPanel.tsx
@@ -43,30 +43,6 @@ export default function DebugPanel({
       </Row>
 
       <Row>
-        Hash Attribute:{" "}
-        <div className="gb-text-white">
-          <ul className="gb-ml-4 gb-list-disc">
-            <li>
-              <code className="gb-text-xs gb-inline-block gb-max-w-full gb-whitespace-nowrap gb-text-ellipsis gb-overflow-hidden gb-bg-white gb-text-red-600 gb-rounded gb-px-1">
-                {hashAttribute ? hashAttribute : ""}
-              </code>
-            </li>
-            <li>
-              {hasHashAttribute ? (
-                <>
-                  <GreenCheck /> Attribute is set
-                </>
-              ) : (
-                <>
-                  <RedX /> Attribute is not set
-                </>
-              )}
-            </li>
-          </ul>
-        </div>
-      </Row>
-
-      <Row>
         Visual Changeset ID:{" "}
         <div className="gb-text-white">
           {visualChangeset ? visualChangeset.id : "N/A"}
@@ -91,6 +67,30 @@ export default function DebugPanel({
             Version: {sdkVersion ? sdkVersion : "Not detected"}
           </li>
         </ul>
+      </Row>
+
+      <Row>
+        Hash Attribute:{" "}
+        <div className="gb-text-white">
+          <ul className="gb-ml-4 gb-list-disc">
+            <li>
+              <code className="gb-text-xs gb-inline-block gb-max-w-full gb-whitespace-nowrap gb-text-ellipsis gb-overflow-hidden gb-bg-white gb-text-red-600 gb-rounded gb-px-1">
+                {hashAttribute ? hashAttribute : ""}
+              </code>
+            </li>
+            <li>
+              {hasHashAttribute ? (
+                <>
+                  <GreenCheck /> Attribute is set
+                </>
+              ) : (
+                <>
+                  <RedX /> Attribute is not set
+                </>
+              )}
+            </li>
+          </ul>
+        </div>
       </Row>
 
       <Row>

--- a/src/visual_editor/components/FloatingUndoButton.tsx
+++ b/src/visual_editor/components/FloatingUndoButton.tsx
@@ -13,7 +13,7 @@ export default function FloatingUndoButton({
   if (!parentElement) return null;
   return (
     <div
-      className="gb-fixed gb-px-2 gb-py-1 gb-text-indigo-800 gb-bg-white gb-text-xs gb-z-front gb-cursor-pointer gb-font-semibold"
+      className="gb-fixed gb-px-2 gb-py-1 gb-text-white gb-bg-indigo-800 gb-text-xs gb-z-front gb-cursor-pointer gb-font-semibold"
       style={{
         top: domRect.top - (26 + 8),
         left: domRect.left + domRect.width - 44.47,

--- a/src/visual_editor/components/MoveElementHandle.tsx
+++ b/src/visual_editor/components/MoveElementHandle.tsx
@@ -12,7 +12,7 @@ const MoveElementHandle = forwardRef<
   return (
     <div
       ref={ref}
-      className="gb-fixed gb-px-2 gb-py-1 gb-text-indigo-800 gb-bg-white gb-text-xs gb-z-front gb-cursor-move gb-font-semibold"
+      className="gb-fixed gb-px-2 gb-py-1 gb-text-white gb-bg-indigo-800 gb-text-xs gb-z-front gb-cursor-move gb-font-semibold"
       style={{
         top: domRect.bottom + 8,
         left: domRect.left + domRect.width - 40,

--- a/src/visual_editor/components/SDKWarning.tsx
+++ b/src/visual_editor/components/SDKWarning.tsx
@@ -1,30 +1,42 @@
 import React from "react";
 import { RxExclamationTriangle } from "react-icons/rx";
+import Tooltip from "./Tooltip";
 
 export default function SDKWarning({
   hasSDK,
   hasLatest,
+  hasHashAttribute,
+  hashAttribute,
 }: {
   hasSDK: boolean;
   hasLatest: boolean;
+  hasHashAttribute: boolean;
+  hashAttribute: string;
 }) {
-  if (hasSDK && hasLatest) return null;
+  if (hasSDK && hasLatest && hasHashAttribute) return null;
 
   return (
-    <div className="gb-text-xs gb-flex gb-text-yellow-600 gb-items-center gb-py-2">
-      <div>
-        <RxExclamationTriangle className="gb-mr-1" />
+    <Tooltip label="An issue has been detected that will prevent visual experiments from rendering correctly for users. Your changes will be saved however they may not work as expected when the experiment is run.">
+      <div className="gb-text-xs gb-flex gb-text-yellow-600 gb-items-center  gb-py-2">
+        <div>
+          <RxExclamationTriangle className="gb-mr-1" />
+        </div>
+        <div className="gb-text-left gb-px-2">
+          {!hasSDK ? (
+            <>GrowthBook SDK not detected on this page.</>
+          ) : !hasHashAttribute ? (
+            <>
+              Your GrowthBook SDK is missing its hash attribute. Please be sure
+              to set the attribute '{hashAttribute}' when loading the SDK.
+            </>
+          ) : (
+            <>
+              GrowthBook SDK on this page is out of date. Features may not work
+              as expected.
+            </>
+          )}
+        </div>
       </div>
-      <div>
-        {!hasSDK ? (
-          <>GrowthBook SDK not detected on this page.</>
-        ) : (
-          <>
-            GrowthBook SDK on this page is out of date. Features may not work as
-            expected.
-          </>
-        )}
-      </div>
-    </div>
+    </Tooltip>
   );
 }

--- a/src/visual_editor/components/Tooltip.tsx
+++ b/src/visual_editor/components/Tooltip.tsx
@@ -16,9 +16,9 @@ const Tooltip = ({
         {/* @ts-expect-error */}
         <RadixTooltip.Portal container={shadowRoot}>
           <RadixTooltip.Content sideOffset={5} asChild>
-            <div className="gb-z-max gb-bg-white gb-text-xs gb-rounded gb-px-2 gb-py-1 gb-shadow-md">
+            <div className="gb-z-max gb-bg-slate-700 gb-text-xs gb-text-slate-300 gb-rounded gb-px-4 gb-py-2 gb-shadow-lg gb-max-w-sm">
               {label}
-              <RadixTooltip.Arrow className="gb-fill-white" />
+              <RadixTooltip.Arrow className="gb-fill-slate-700" />
             </div>
           </RadixTooltip.Content>
         </RadixTooltip.Portal>

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -56,8 +56,6 @@ const VisualEditor: FC<{}> = () => {
     rightAligned: true,
   });
 
-  const { hasSDK, hasLatest, version } = useSDKDiagnostics();
-
   const {
     params,
     visualChangesetId,
@@ -75,6 +73,11 @@ const VisualEditor: FC<{}> = () => {
     experiment,
     visualChangeset,
   } = useVisualChangeset(visualChangesetId);
+
+  const { hasSDK, hasLatest, version, hashAttribute, hasHashAttribute } =
+    useSDKDiagnostics({
+      experiment,
+    });
 
   const {
     loading: aiLoading,
@@ -302,6 +305,8 @@ const VisualEditor: FC<{}> = () => {
               visualChangeset={visualChangeset}
               hasSDK={hasSDK}
               sdkVersion={version}
+              hashAttribute={hashAttribute}
+              hasHashAttribute={hasHashAttribute}
             />
           </VisualEditorSection>
         )}
@@ -321,7 +326,12 @@ const VisualEditor: FC<{}> = () => {
             visualChangesetId={visualChangesetId}
             hasAiEnabled={hasAiEnabled}
           />
-          <SDKWarning hasSDK={hasSDK} hasLatest={hasLatest} />
+          <SDKWarning
+            hasSDK={hasSDK}
+            hasLatest={hasLatest}
+            hasHashAttribute={hasHashAttribute}
+            hashAttribute={hashAttribute}
+          />
         </div>
       </VisualEditorPane>
 

--- a/src/visual_editor/lib/hooks/useSDKDiagnostics.ts
+++ b/src/visual_editor/lib/hooks/useSDKDiagnostics.ts
@@ -1,21 +1,26 @@
 import React, { useEffect, useState } from "react";
+import { APIExperiment } from "../../../../devtools";
 
 // technically doesn't have to be the latest version but the most recent version
 // with breaking changes
 const LATEST_SDK_VERSION = "0.30.0";
 
-type UseSDKDiagnosticsHook = () => {
+type UseSDKDiagnosticsHook = (args: { experiment: APIExperiment | null }) => {
   hasSDK: boolean;
   hasLatest: boolean;
   version: string;
+  hashAttribute: string;
+  hasHashAttribute: boolean;
 };
 
-const useSDKDiagnostics: UseSDKDiagnosticsHook = () => {
+const useSDKDiagnostics: UseSDKDiagnosticsHook = ({ experiment }) => {
   const [{ hasSDK, hasLatest }, setSDKStatus] = useState({
     hasSDK: false,
     hasLatest: false,
   });
   const [version, setVersion] = useState("");
+  const [hashAttribute, setHashAttr] = useState("");
+  const [hasHashAttribute, setHasHashAttr] = useState(false);
 
   useEffect(() => {
     if (!window) return;
@@ -27,10 +32,26 @@ const useSDKDiagnostics: UseSDKDiagnosticsHook = () => {
       setVersion(window._growthbook?.version || "");
   }, [setSDKStatus]);
 
+  useEffect(() => {
+    setHashAttr(experiment?.hashAttribute || "");
+  }, [experiment]);
+
+  useEffect(() => {
+    // @ts-expect-error we are accessing a private property on gb sdk obj
+    const sdkAttributes = hasSDK ? window._growthbook?._ctx?.attributes : {};
+    setHasHashAttr(
+      hasSDK
+        ? sdkAttributes.hasOwnProperty(experiment?.hashAttribute || "")
+        : false
+    );
+  }, [hasSDK, hashAttribute]);
+
   return {
     hasSDK,
     hasLatest,
     version,
+    hashAttribute,
+    hasHashAttribute,
   };
 };
 


### PR DESCRIPTION
Changes:
- Check to see if hash attribute is set on the local SDK; warn user if not
- Provide helpful tooltip for SDK warnings message
  - Improve tooltip styling

Screenshots:
<img width="347" alt="Screenshot 2023-11-13 at 11 28 12 AM" src="https://github.com/growthbook/devtools/assets/2374625/6fe2291c-3185-4890-ac75-ce3239267de0">
<img width="384" alt="Screenshot 2023-11-13 at 11 28 24 AM" src="https://github.com/growthbook/devtools/assets/2374625/1545762e-3380-4de9-b04b-7261b8447856">
<img width="375" alt="Screenshot 2023-11-13 at 11 35 35 AM" src="https://github.com/growthbook/devtools/assets/2374625/deaa0c4b-9f5f-4985-87fa-e39e76a3505d">
<img width="425" alt="Screenshot 2023-11-13 at 11 42 37 AM" src="https://github.com/growthbook/devtools/assets/2374625/818f44f6-bab2-45f2-ba44-b84a3f9bfffe">

