### PR TITLE
Remove activeTab permission

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -34,7 +34,7 @@
     "service_worker": "js/background.js"
   },
 
-  "permissions": ["storage", "activeTab"],
+  "permissions": ["storage"],
 
   "host_permissions": ["<all_urls>"],
 


### PR DESCRIPTION
Per Chrome Web Store's recent rejection reason, we aren't using the `activeTab` permission anymore so this PR removes it.