### PR TITLE
Persist overrides through inspected window refreshes

### DIFF
--- a/src/devtools/ui/App.tsx
+++ b/src/devtools/ui/App.tsx
@@ -37,6 +37,15 @@ function App(props: Props) {
   // Filter search term
   const [q, setQ] = useState("");
 
+  // run on every render
+  useEffect(() => {
+    setOverrides({
+      attributes: attrOverrides || {},
+      features: forcedFeatureValues,
+      variations: forcedVars,
+    });
+  });
+
   // When overrides change, update the page
   useEffect(() => {
     setOverrides({


### PR DESCRIPTION
This was a feature requested by a user in the community Slack. This ensures that any overrides made in the DevTools panel persist when the inspected window is refreshed.