### PR TITLE
add option to search by attr

### DIFF
--- a/src/visual_editor/lib/getSelector.ts
+++ b/src/visual_editor/lib/getSelector.ts
@@ -5,6 +5,7 @@ export default function getSelector(element: Element) {
   try {
     selector = finder(element, {
       seedMinLength: 3,
+      attr: (name) => name === "data-growthbook-element-id",
     });
   } catch (e) {
     selector =

--- a/yarn.lock
+++ b/yarn.lock
@@ -1246,10 +1246,10 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
   integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
 
-"@growthbook/growthbook@^0.30.0":
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-0.30.0.tgz#52532c2d5dfa7c017815027678bb241421c308b1"
-  integrity sha512-ennMHKZIhAZokHHcnA9/tOTLFdBB4DQR0WHT8Lf1pD80jWVv8JBCAzsV1jzSjYUQhb8R8pLR2Kho0IfgjzIZGQ==
+"@growthbook/growthbook@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-0.31.0.tgz#66273344805c45dc406940ab719856385afa4750"
+  integrity sha512-VtI5IibZHhvtrlZhfopGYhVXZ++FewgY0BtQQyEqFSrhCYFvEEtq+GkuSm4GcC0JxNuHiYJr9/R3GpffJV/T4Q==
   dependencies:
     dom-mutator "^0.6.0"
 


### PR DESCRIPTION
To give you some background info. We faced a need to be able to have a custom selector to be able to allow our product team to set up experiments with your visual editor. We could not rely on your editor's selectors from classes because our classes contain hashes that can randomly change because we use CSS modules. We needed a way to assign custom, non-changing IDs to our text elements and we could not use native HTML element IDs because we could not guarantee page-wide uniqueness (we use Intl message IDs as IDs for your tool) A custom attribute specifically for Growthbook was the best option for us. So here is a PR that allows you to specify an identifier attribute that will be preferred by Growthbook when composing the selector.