### PR TITLE
Bugfix - Persist forced feature values through refresh

### DIFF
--- a/src/devtools/ui/Feature.tsx
+++ b/src/devtools/ui/Feature.tsx
@@ -17,7 +17,7 @@ import {
 } from "@chakra-ui/layout";
 import { Textarea } from "@chakra-ui/textarea";
 import stringify from "json-stringify-pretty-compact";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { MdEdit, MdHistory } from "react-icons/md";
 import DebugLog from "./DebugLog";
@@ -58,6 +58,12 @@ export default function Feature({
   });
 
   const isBoolean = result.value === true || result.value === false;
+
+  // ensure we persist the forced value when page is reloaded
+  useEffect(() => {
+    if (!isForced) return;
+    forceValue(result.value);
+  }, [result, feature, isForced]);
 
   return (
     <AccordionItem>


### PR DESCRIPTION
This PR fixes an issue in our DevTools extension where forced values do not persist through refreshes of the inspected window.

Reports from customers:
- https://growthbookusers.slack.com/archives/C01T6Q1SVFV/p1706801125408999
- https://share.vidyard.com/watch/LjrLjdHJMQyCx1gsFaaZ8X

Screencap:
![Feb-26-2024 09-57-28](https://github.com/growthbook/devtools/assets/2374625/422d3a7e-c613-4a74-8740-bda610b8e5a7)
