### PR TITLE
Optimize css flow

### DIFF
--- a/devtools.d.ts
+++ b/devtools.d.ts
@@ -4,7 +4,6 @@ import type {
   ExperimentOverride,
 } from "@growthbook/growthbook";
 import {
-  BGErrorCode,
   FetchVisualChangesetPayload,
   TransformCopyPayload,
   UpdateVisualChangesetPayload,
@@ -19,8 +18,6 @@ declare global {
 export type DebugLogs = [string, any][];
 
 export type CopyMode = "energetic" | "concise" | "humorous";
-
-export type ErrorCode = "csp-error" | BGErrorCode;
 
 export type CSPError = {
   violatedDirective: string;

--- a/src/background.ts
+++ b/src/background.ts
@@ -23,14 +23,6 @@ const genHeaders = (apiKey: string) => ({
   ["Content-Type"]: "application/json",
 });
 
-export type BGErrorCode =
-  | "no-api-key"
-  | "no-api-host"
-  | "load-viz-changeset-failed"
-  | "update-viz-changeset-failed"
-  | "transform-copy-failed"
-  | "transform-copy-daily-limit-reached";
-
 export type FetchVisualChangesetPayload =
   | {
       visualChangeset: APIVisualChangeset;
@@ -41,7 +33,8 @@ export type FetchVisualChangesetPayload =
   | {
       visualChangeset: null;
       experiment: null;
-      error: BGErrorCode;
+      experimentUrl: null;
+      error: string;
     };
 
 const fetchVisualChangeset = async ({
@@ -92,7 +85,7 @@ const fetchVisualChangeset = async ({
       error: null,
     };
   } catch (e: any) {
-    let error: BGErrorCode = "load-viz-changeset-failed";
+    let error: string = e.message;
 
     if (e.message === "no-api-key" || e.message === "no-api-host") {
       error = e.message;
@@ -101,6 +94,7 @@ const fetchVisualChangeset = async ({
     return {
       visualChangeset: null,
       experiment: null,
+      experimentUrl: null,
       error,
     };
   }
@@ -115,7 +109,7 @@ export type UpdateVisualChangesetPayload =
   | {
       nModified: number;
       visualChangeset: null;
-      error: BGErrorCode;
+      error: string;
     };
 
 const updateVisualChangeset = async ({
@@ -150,7 +144,7 @@ const updateVisualChangeset = async ({
       error: null,
     };
   } catch (e: any) {
-    let error: BGErrorCode = "update-viz-changeset-failed";
+    let error = e.string;
 
     if (e.message === "no-api-key" || e.message === "no-api-host") {
       error = e.message;
@@ -175,7 +169,7 @@ export type TransformCopyPayload =
       visualChangeset: null;
       transformed: null;
       dailyLimitReached: null;
-      error: BGErrorCode;
+      error: string;
     };
 
 const transformCopy = async ({
@@ -215,7 +209,7 @@ const transformCopy = async ({
       error: null,
     };
   } catch (e: any) {
-    let error: BGErrorCode = "transform-copy-failed";
+    let error = e.message;
 
     if (e.message === "no-api-key" || e.message === "no-api-host") {
       error = e.message;

--- a/src/visual_editor/components/ErrorDisplay.tsx
+++ b/src/visual_editor/components/ErrorDisplay.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, FC, useEffect } from "react";
-import { CSPError, ErrorCode, OpenOptionsPageMessage } from "../../../devtools";
+import { CSPError, OpenOptionsPageMessage } from "../../../devtools";
 
 const CSPErrorDisplay = ({ cspError }: { cspError: CSPError | null }) => (
   <div className="gb-p-4 gb-text-red-400">
@@ -19,7 +19,7 @@ const CSPErrorDisplay = ({ cspError }: { cspError: CSPError | null }) => (
 );
 
 interface ErrorDisplayProps {
-  error: ErrorCode;
+  error: string | null;
   cspError: CSPError | null;
 }
 const ErrorDisplay: FC<ErrorDisplayProps> = ({ error, cspError }) => {
@@ -50,34 +50,6 @@ const ErrorDisplay: FC<ErrorDisplayProps> = ({ error, cspError }) => {
       );
     case "csp-error":
       return <CSPErrorDisplay cspError={cspError} />;
-    case "load-viz-changeset-failed":
-      return (
-        <div className="gb-p-4 gb-text-red-400">
-          Failed to load the visual experiment from the server. Please try
-          again, or contact support with the error code: '{error}'.
-        </div>
-      );
-    case "update-viz-changeset-failed":
-      return (
-        <div className="gb-p-4 gb-text-red-400">
-          Failed to save updates to the visual experiment. Please try again, or
-          contact support with the error code: '{error}'.
-        </div>
-      );
-    case "transform-copy-failed":
-      return (
-        <div className="gb-p-4 gb-text-red-400">
-          Something went wrong while trying to generate copy. Please try again,
-          or contact support with the error code: '{error}'.
-        </div>
-      );
-    case "transform-copy-daily-limit-reached":
-      return (
-        <div className="gb-p-4 gb-text-red-400">
-          You have reached your daily limit for generating copy. Please try
-          again tomorrow.
-        </div>
-      );
     default:
       return (
         <div className="gb-p-4 gb-text-red-400">

--- a/src/visual_editor/components/GlobalCSSEditor.tsx
+++ b/src/visual_editor/components/GlobalCSSEditor.tsx
@@ -7,17 +7,17 @@ const GlobalCSSEditor: FC<{
   const [css, setCss] = useState(incomingCss);
 
   useEffect(() => {
-    onSubmit(css);
+    if (css !== incomingCss) onSubmit(css);
   }, [css]);
 
   useEffect(() => {
-    setCss(incomingCss);
+    if (incomingCss !== css) setCss(incomingCss);
   }, [incomingCss]);
 
   return (
     <div className="gb-px-4 gb-pb-4">
       <textarea
-        className="gb-w-full gb-h-64 gb-rounded gb-p-2"
+        className="gb-w-full gb-h-64 gb-rounded gb-p-2 gb-text-black"
         placeholder="Enter CSS here"
         value={css}
         onChange={(e) => setCss(e.currentTarget.value)}

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -10,7 +10,7 @@ import React, {
 } from "react";
 import * as ReactDOM from "react-dom/client";
 
-import { ErrorCode, VisualEditorVariation } from "../../devtools";
+import { VisualEditorVariation } from "../../devtools";
 import useFixedPositioning from "./lib/hooks/useFixedPositioning";
 import useQueryParams from "./lib/hooks/useQueryParams";
 import useVisualChangeset from "./lib/hooks/useVisualChangeset";
@@ -312,10 +312,7 @@ const VisualEditor: FC<{}> = () => {
         )}
 
         {error || aiError ? (
-          <ErrorDisplay
-            error={(error || aiError) as ErrorCode}
-            cspError={cspError}
-          />
+          <ErrorDisplay error={error || aiError} cspError={cspError} />
         ) : null}
 
         <div className="gb-m-4 gb-text-center">

--- a/src/visual_editor/lib/hooks/useAiCopySuggestion.ts
+++ b/src/visual_editor/lib/hooks/useAiCopySuggestion.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   Message,
-  ErrorCode,
   CopyMode,
   TransformCopyRequestMessage,
 } from "../../../../devtools";
@@ -10,7 +9,7 @@ export type TransformCopyFn = (copy: string, mode: CopyMode) => void;
 
 type UseAiCopySuggestionHook = (visualChangesetId: string) => {
   loading: boolean;
-  error: ErrorCode | null;
+  error: string | null;
   transformedCopy: string | null;
   transformCopy: TransformCopyFn;
 };
@@ -20,7 +19,7 @@ type UseAiCopySuggestionHook = (visualChangesetId: string) => {
  * AI copy suggestions.
  */
 const useAiCopySuggestion: UseAiCopySuggestionHook = (visualChangesetId) => {
-  const [error, setError] = useState<ErrorCode | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [transformedCopy, setTransformedCopy] = useState<string | null>(null);
 

--- a/src/visual_editor/lib/hooks/useGlobalCSS.ts
+++ b/src/visual_editor/lib/hooks/useGlobalCSS.ts
@@ -1,5 +1,5 @@
 import { debounce } from "lodash";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { VisualEditorVariation } from "../../../../devtools";
 
 let _globalStyleTag: HTMLStyleElement | null = null;
@@ -18,16 +18,21 @@ export default function useGlobalCSS({
   globalCss: string;
   setGlobalCss: (globalCss: string) => void;
 } {
-  const setGlobalCss = debounce((css: string) => {
-    updateVariation({ css });
-  }, 500);
+  const setGlobalCss = useCallback(
+    debounce((css: string) => {
+      updateVariation({ css });
+    }, 1500),
+    [updateVariation]
+  );
 
   useEffect(() => {
-    if (_globalStyleTag) _globalStyleTag.remove();
     if (!variation?.css) return;
     _globalStyleTag = document.createElement("style");
     document.head.appendChild(_globalStyleTag);
     _globalStyleTag.innerHTML = variation?.css ?? "";
+    return () => {
+      if (_globalStyleTag) _globalStyleTag.remove();
+    };
   }, [variation]);
 
   return {

--- a/src/visual_editor/lib/hooks/useVisualChangeset.ts
+++ b/src/visual_editor/lib/hooks/useVisualChangeset.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import {
-  ErrorCode,
   CSPError,
   VisualEditorVariation,
   Message,
@@ -18,7 +17,7 @@ type UseVisualChangesetHook = (visualChangesetId: string) => {
     index: number,
     updates: Partial<VisualEditorVariation>
   ) => void;
-  error: ErrorCode | null;
+  error: string | null;
   cspError: CSPError | null;
   experiment: APIExperiment | null;
   visualChangeset: APIVisualChangeset | null;
@@ -29,7 +28,7 @@ type UseVisualChangesetHook = (visualChangesetId: string) => {
  * `window.postMessage` API to communicate with the background script.
  */
 const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
-  const [error, setError] = useState<ErrorCode | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [cspError, setCSPError] = useState<CSPError | null>(null);
   const [visualChangeset, setVisualChangeset] =

--- a/src/visual_editor/lib/hooks/useVisualChangeset.ts
+++ b/src/visual_editor/lib/hooks/useVisualChangeset.ts
@@ -85,6 +85,7 @@ const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
         ...(variations?.map((v, i) => (i === index ? newVariation : v)) ?? []),
       ];
       updateVisualChangeset(newVariations);
+      setVariations(newVariations);
     },
     [variations, setVariations, updateVisualChangeset]
   );
@@ -119,7 +120,6 @@ const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
           break;
         case "GB_RESPONSE_UPDATE_VISUAL_CHANGESET":
           if (msg.data.error) setError(msg.data.error);
-          else setVisualChangeset(msg.data.visualChangeset);
           setLoading(false);
           break;
         default:


### PR DESCRIPTION
Users were experiencing issues editing the Global CSS of a page. This was primarily due to two reasons:

- the CSS saving pipeline was unoptimized (save requests made when no changes were effected)
- we got rid of optimistic saving a while ago, and it has cause some minor degradation of quality in UX; global CSS showing the extreme case. 

This PR addresses the above two issues. In addition, we remove the use of error codes and instead use actual error messages instead, which should be more helpful in support situations.