### PR TITLE
Search for 'data-' attrs; Allow ignoring class names

### DIFF
--- a/src/visual_editor/components/ElementDetails/DetailsRow.tsx
+++ b/src/visual_editor/components/ElementDetails/DetailsRow.tsx
@@ -43,7 +43,7 @@ const DetailsRow = ({
 
   return (
     <div
-      className={clsx("gb-flex gb-mb-2 last:gb-mb-0", {
+      className={clsx("gb-flex", {
         "flex-col": editing,
       })}
     >

--- a/src/visual_editor/components/ElementDetails/index.tsx
+++ b/src/visual_editor/components/ElementDetails/index.tsx
@@ -6,29 +6,54 @@ const ElementDetails: FC<{
   element: HTMLElement;
   setHTML: (html: string) => void;
   undoHTMLMutations?: () => void;
-}> = ({ element, selector, setHTML, undoHTMLMutations }) => {
+  ignoreClassNames: boolean;
+  setIgnoreClassNames: (value: boolean) => void;
+}> = ({
+  element,
+  selector,
+  setHTML,
+  undoHTMLMutations,
+  ignoreClassNames,
+  setIgnoreClassNames,
+}) => {
   const name = element.tagName;
   const html = element.innerHTML;
   const isHtmlTooLarge = html.length > 100000;
 
   return (
     <div className="gb-text-light gb-flex gb-flex-col gb-ml-4">
-      <DetailsRow label="Selector" value={selector} readOnly />
-      <DetailsRow label="Tag name" value={name} readOnly />
-      {isHtmlTooLarge ? (
-        <DetailsRow
-          readOnly
-          label="Inner HTML"
-          value={"HTML is too large to display"}
-        />
-      ) : (
-        <DetailsRow
-          label="Inner HTML"
-          value={html}
-          onSave={setHTML}
-          onUndo={undoHTMLMutations}
-        />
-      )}
+      <div className="gb-mb-2">
+        <DetailsRow label="Selector" value={selector} readOnly />
+        <label className="gb-text-xs gb-flex gb-items-center gb-my-1">
+          <input
+            className="gb-mr-2"
+            type="checkbox"
+            checked={ignoreClassNames}
+            onChange={(e) => setIgnoreClassNames(e.target.checked)}
+          />
+          Ignore class names
+        </label>
+      </div>
+
+      <div className="gb-mb-2">
+        <DetailsRow label="Tag name" value={name} readOnly />
+      </div>
+      <div className="gb-mb-2">
+        {isHtmlTooLarge ? (
+          <DetailsRow
+            readOnly
+            label="Inner HTML"
+            value={"HTML is too large to display"}
+          />
+        ) : (
+          <DetailsRow
+            label="Inner HTML"
+            value={html}
+            onSave={setHTML}
+            onUndo={undoHTMLMutations}
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -126,6 +126,8 @@ const VisualEditor: FC<{}> = () => {
     addDomMutation,
     removeDomMutation,
     setDomMutations,
+    ignoreClassNames,
+    setIgnoreClassNames,
   } = useEditMode({
     isEnabled: mode === "edit",
     variation: selectedVariation,
@@ -209,6 +211,8 @@ const VisualEditor: FC<{}> = () => {
                 element={elementUnderEdit}
                 setHTML={setInnerHTML}
                 undoHTMLMutations={undoInnerHTMLMutations}
+                ignoreClassNames={ignoreClassNames}
+                setIgnoreClassNames={setIgnoreClassNames}
               />
             </VisualEditorSection>
 

--- a/src/visual_editor/lib/getSelector.ts
+++ b/src/visual_editor/lib/getSelector.ts
@@ -1,10 +1,15 @@
 import { finder } from "@medv/finder";
 
-export default function getSelector(element: Element) {
+export default function getSelector(
+  element: Element,
+  options?: { ignoreClassNames: boolean }
+) {
   let selector = "";
   try {
     selector = finder(element, {
       seedMinLength: 3,
+      ...(options?.ignoreClassNames && { className: () => false }),
+      attr: (name) => name.startsWith("data-"),
     });
   } catch (e) {
     selector =

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -47,6 +47,9 @@ type UseEditModeHook = (args: {
   addDomMutation: (mutation: DeclarativeMutation) => void;
   removeDomMutation: (mutation: DeclarativeMutation) => void;
   setDomMutations: (mutations: DeclarativeMutation[]) => void;
+
+  ignoreClassNames: boolean;
+  setIgnoreClassNames: (ignore: boolean) => void;
 };
 
 /**
@@ -62,6 +65,7 @@ const useEditMode: UseEditModeHook = ({
   const [elementUnderEdit, setElementUnderEdit] = useState<HTMLElement | null>(
     null
   );
+  const [ignoreClassNames, setIgnoreClassNames] = useState(false);
   const [highlightedElement, setHighlightedElement] =
     useState<HTMLElement | null>(null);
   const clearElementUnderEdit = useCallback(
@@ -69,12 +73,22 @@ const useEditMode: UseEditModeHook = ({
     [setElementUnderEdit]
   );
   const elementUnderEditSelector = useMemo(
-    () => (elementUnderEdit ? getSelector(elementUnderEdit) : ""),
-    [elementUnderEdit]
+    () =>
+      elementUnderEdit
+        ? getSelector(elementUnderEdit, {
+            ignoreClassNames,
+          })
+        : "",
+    [elementUnderEdit, ignoreClassNames]
   );
   const highlightedElementSelector = useMemo(
-    () => (highlightedElement ? getSelector(highlightedElement) : ""),
-    [highlightedElement]
+    () =>
+      highlightedElement
+        ? getSelector(highlightedElement, {
+            ignoreClassNames,
+          })
+        : "",
+    [highlightedElement, ignoreClassNames]
   );
   const elementUnderEditCopy = useMemo(() => {
     if (!elementUnderEdit) return "";
@@ -191,7 +205,7 @@ const useEditMode: UseEditModeHook = ({
         ]);
       });
     },
-    [elementUnderEdit, addDomMutations]
+    [elementUnderEdit, addDomMutations, elementUnderEditSelector]
   );
 
   const addClassNames = useCallback(
@@ -351,6 +365,8 @@ const useEditMode: UseEditModeHook = ({
     removeDomMutation,
     addDomMutation,
     setDomMutations,
+    ignoreClassNames,
+    setIgnoreClassNames,
   };
 };
 


### PR DESCRIPTION
This is to help users with websites that have changing class names. If they use any `data-` attributes, those will also be leveraged to form a unique selector.

<img width="366" alt="Screenshot 2024-04-11 at 3 48 45 PM" src="https://github.com/growthbook/devtools/assets/2374625/fd83e96f-4e27-4f50-9015-a74cfda0d4db">
<img width="353" alt="Screenshot 2024-04-11 at 3 56 39 PM" src="https://github.com/growthbook/devtools/assets/2374625/ce4dd490-86c4-4992-8dd0-b3e71c17a119">
