### PR TITLE
Specify charset for visual_editor.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@chakra-ui/react": "^2.4.9",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@growthbook/growthbook": "^0.36.0",
+    "@growthbook/growthbook": "^1.1.0",
     "@medv/finder": "^2.1.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.0.7",

--- a/src/content_script/index.ts
+++ b/src/content_script/index.ts
@@ -71,6 +71,7 @@ if (
   const script = document.createElement("script");
   script.id = VISUAL_EDITOR_SCRIPT_ID;
   script.async = true;
+  script.charset = "utf-8";
   script.src = chrome.runtime.getURL("js/visual_editor.js");
 
   document.body.appendChild(script);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1246,10 +1246,10 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
   integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
 
-"@growthbook/growthbook@^0.36.0":
-  version "0.36.0"
-  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-0.36.0.tgz#84d704bb8beae68db592b8f979f36d0f85202d6b"
-  integrity sha512-5u1x34H7pg5zS5db3UZ1Pn5hL/jj1EOWdUuz5tSIDUfW49TOWtxtrOAx0Qu1B+UmrIcZKE5XJr6TmWdmdOK12g==
+"@growthbook/growthbook@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-1.1.0.tgz#3b9503a1e774c2888637152b0679d8a0df3d50cf"
+  integrity sha512-TBgUnMcYxOVo4dDDZJ8J2Z9DjDy9PlL+J2GpLMMD6SPpw66gSDcnnwGk9H6diHS/IuUmDXNkU+24+L/bXulWww==
   dependencies:
     dom-mutator "^0.6.0"
 


### PR DESCRIPTION
This will fix the dreaded charset bug when a page does not have `<meta charset="utf-8">` defined on their HTML page.

## Before
<img width="1624" alt="Screenshot 2024-07-08 at 3 39 04 PM" src="https://github.com/growthbook/devtools/assets/2374625/ba3f9c08-5030-411a-9b3a-395c1cf67a2a">

<img width="838" alt="Screenshot 2024-07-08 at 3 38 28 PM" src="https://github.com/growthbook/devtools/assets/2374625/916d1b39-0a76-4750-b502-35544b9ddd87">

## After
<img width="1624" alt="Screenshot 2024-07-08 at 3 41 13 PM" src="https://github.com/growthbook/devtools/assets/2374625/e61409e0-874e-4cf2-a8cd-52352264a552">
