### PR TITLE
Gl/inline edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-tooltip": "^1.1.2",
     "clsx": "^2.1.1",
-    "dom-mutator": "^0.6.0",
+    "dom-mutator": "^0.7.0",
     "framer-motion": "^11.3.24",
     "json-stringify-pretty-compact": "^4.0.0",
     "lodash": "^4.17.21",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "GrowthBook DevTools",
   "description": "GrowthBook's Visual Editor and SDK Debugger",
-  "version": "0.3.9",
+  "version": "0.4.0",
 
   "options_ui": {
     "page": "options.html"

--- a/src/background.ts
+++ b/src/background.ts
@@ -52,7 +52,7 @@ const fetchVisualChangeset = async ({
       `${apiHost}/api/v1/visual-changesets/${visualChangesetId}?includeExperiment=1`,
       {
         headers: genHeaders(apiKey),
-      }
+      },
     );
 
     const res = await response.json();
@@ -131,7 +131,7 @@ const updateVisualChangeset = async ({
         headers: genHeaders(apiKey),
         method: "PUT",
         body: JSON.stringify(updatePayload),
-      }
+      },
     );
 
     const res = await resp.json();
@@ -256,7 +256,7 @@ const isSameOrigin = (url: string, origin: string) => {
         origin,
       });
       throw new Error(
-        'Unrecognizable domain type for either "url" or "origin"'
+        'Unrecognizable domain type for either "url" or "origin"',
       );
     }
   } catch (e) {
@@ -301,7 +301,7 @@ chrome.runtime.onMessage.addListener(
               !isSameOrigin(editorUrl, senderOrigin)
             )
               throw new Error(
-                `Unable to verify sender origin (editorUrl: ${editorUrl}; senderOrigin: ${senderOrigin})`
+                `Unable to verify sender origin (editorUrl: ${editorUrl}; senderOrigin: ${senderOrigin})`,
               );
             return updateVisualChangeset(data);
           })
@@ -330,5 +330,5 @@ chrome.runtime.onMessage.addListener(
 
     // return true to indicate async response
     return true;
-  }
+  },
 );

--- a/src/background.ts
+++ b/src/background.ts
@@ -47,6 +47,7 @@ const fetchVisualChangeset = async ({
 
     if (!apiKey || !apiHost)
       throw new Error(!apiKey ? "no-api-key" : "no-api-host");
+
     const response = await fetch(
       `${apiHost}/api/v1/visual-changesets/${visualChangesetId}?includeExperiment=1`,
       {
@@ -84,7 +85,6 @@ const fetchVisualChangeset = async ({
       error: null,
     };
   } catch (e: any) {
-
     let error: string = e.message;
 
     if (e.message === "no-api-key" || e.message === "no-api-host") {
@@ -145,9 +145,11 @@ const updateVisualChangeset = async ({
     };
   } catch (e: any) {
     let error = e.string;
+
     if (e.message === "no-api-key" || e.message === "no-api-host") {
       error = e.message;
     }
+
     return {
       nModified: 0,
       visualChangeset: null,
@@ -305,7 +307,6 @@ chrome.runtime.onMessage.addListener(
           })
           .then((res) => {
             if (res.error) throw new Error(res.error);
-
             sendResponse(res);
           })
           .catch((e) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -73,7 +73,6 @@ const fetchVisualChangeset = async ({
       if (appOrigin) await saveAppOrigin(appOrigin);
     } catch (e) {
       // fail silently
-      throw new Error("failed-fetching-app-origin");
     }
 
     return {
@@ -135,9 +134,8 @@ const updateVisualChangeset = async ({
       }
     );
 
-
     const res = await resp.json();
-    const bkg = chrome.extension.getBackgroundPage() as any;
+
     if (resp.status !== 200) throw new Error(res.message ?? resp.statusText);
 
     return {

--- a/src/background.ts
+++ b/src/background.ts
@@ -96,7 +96,7 @@ const fetchVisualChangeset = async ({
       visualChangeset: null,
       experiment: null,
       experimentUrl: null,
-      error: "this is a test error",
+      error,
     };
   }
 };
@@ -138,7 +138,6 @@ const updateVisualChangeset = async ({
 
     const res = await resp.json();
     const bkg = chrome.extension.getBackgroundPage() as any;
-    bkg.console.log("res", res);
     if (resp.status !== 200) throw new Error(res.message ?? resp.statusText);
 
     return {

--- a/src/background.ts
+++ b/src/background.ts
@@ -47,7 +47,6 @@ const fetchVisualChangeset = async ({
 
     if (!apiKey || !apiHost)
       throw new Error(!apiKey ? "no-api-key" : "no-api-host");
-
     const response = await fetch(
       `${apiHost}/api/v1/visual-changesets/${visualChangesetId}?includeExperiment=1`,
       {
@@ -74,6 +73,7 @@ const fetchVisualChangeset = async ({
       if (appOrigin) await saveAppOrigin(appOrigin);
     } catch (e) {
       // fail silently
+      throw new Error("failed-fetching-app-origin");
     }
 
     return {
@@ -85,6 +85,7 @@ const fetchVisualChangeset = async ({
       error: null,
     };
   } catch (e: any) {
+
     let error: string = e.message;
 
     if (e.message === "no-api-key" || e.message === "no-api-host") {
@@ -95,7 +96,7 @@ const fetchVisualChangeset = async ({
       visualChangeset: null,
       experiment: null,
       experimentUrl: null,
-      error,
+      error: "this is a test error",
     };
   }
 };
@@ -134,8 +135,10 @@ const updateVisualChangeset = async ({
       }
     );
 
-    const res = await resp.json();
 
+    const res = await resp.json();
+    const bkg = chrome.extension.getBackgroundPage() as any;
+    bkg.console.log("res", res);
     if (resp.status !== 200) throw new Error(res.message ?? resp.statusText);
 
     return {
@@ -145,11 +148,9 @@ const updateVisualChangeset = async ({
     };
   } catch (e: any) {
     let error = e.string;
-
     if (e.message === "no-api-key" || e.message === "no-api-host") {
       error = e.message;
     }
-
     return {
       nModified: 0,
       visualChangeset: null,
@@ -307,6 +308,7 @@ chrome.runtime.onMessage.addListener(
           })
           .then((res) => {
             if (res.error) throw new Error(res.error);
+
             sendResponse(res);
           })
           .catch((e) => {

--- a/src/content_script/pageMessageHandlers.ts
+++ b/src/content_script/pageMessageHandlers.ts
@@ -83,7 +83,7 @@ export const visualEditorLoadChangesetRequest = (
           ...resp,
         },
       };
-      console.log("message", message);
+
       window.postMessage(message, window.location.origin);
     }
   );

--- a/src/content_script/pageMessageHandlers.ts
+++ b/src/content_script/pageMessageHandlers.ts
@@ -21,7 +21,7 @@ import { VISUAL_CHANGESET_ID_PARAMS_KEY } from "../visual_editor/lib/constants";
 import { saveApiHost, saveApiKey } from "../visual_editor/lib/storage";
 
 export const genericDevtoolsMessagePassThrough = (
-  message: RefreshMessage | ErrorMessage
+  message: RefreshMessage | ErrorMessage,
 ) => {
   chrome.runtime.sendMessage(message);
 };
@@ -29,13 +29,13 @@ export const genericDevtoolsMessagePassThrough = (
 // 1. save key to local storage
 // 2. send response message to content script
 export const visualEditorOpenRequest = (
-  message: OpenVisualEditorRequestMessage
+  message: OpenVisualEditorRequestMessage,
 ) => {
   if (!message.data?.apiKey || !message.data?.apiHost) {
     // TODO send error message back
     console.error(
       "For some reason, the message data is missing either the API key or API host.",
-      message.data
+      message.data,
     );
     return;
   }
@@ -45,7 +45,7 @@ export const visualEditorOpenRequest = (
 
   window.postMessage(
     { type: "GB_RESPONSE_OPEN_VISUAL_EDITOR" },
-    window.location.origin
+    window.location.origin,
   );
 };
 
@@ -64,7 +64,7 @@ export const loadVisualEditorQueryParams = () => {
 };
 
 export const visualEditorLoadChangesetRequest = (
-  msg: LoadVisualChangesetRequestMessage
+  msg: LoadVisualChangesetRequestMessage,
 ) => {
   chrome.runtime.sendMessage<
     BGLoadVisualChangsetMessage,
@@ -85,12 +85,12 @@ export const visualEditorLoadChangesetRequest = (
       };
 
       window.postMessage(message, window.location.origin);
-    }
+    },
   );
 };
 
 export const visualEditorUpdateChangesetRequest = (
-  msg: UpdateVisualChangesetRequestMessage
+  msg: UpdateVisualChangesetRequestMessage,
 ) => {
   chrome.runtime.sendMessage<
     BGUpdateVisualChangsetMessage,
@@ -112,12 +112,12 @@ export const visualEditorUpdateChangesetRequest = (
       };
 
       window.postMessage(message, window.location.origin);
-    }
+    },
   );
 };
 
 export const visualEditorTransformCopyRequest = (
-  msg: TransformCopyRequestMessage
+  msg: TransformCopyRequestMessage,
 ) => {
   chrome.runtime.sendMessage<BGTransformCopyMessage, TransformCopyPayload>(
     {
@@ -136,6 +136,6 @@ export const visualEditorTransformCopyRequest = (
         },
       };
       window.postMessage(message, window.location.origin);
-    }
+    },
   );
 };

--- a/src/content_script/pageMessageHandlers.ts
+++ b/src/content_script/pageMessageHandlers.ts
@@ -83,7 +83,7 @@ export const visualEditorLoadChangesetRequest = (
           ...resp,
         },
       };
-
+      console.log("message", message);
       window.postMessage(message, window.location.origin);
     }
   );

--- a/src/devtools/controller.ts
+++ b/src/devtools/controller.ts
@@ -9,7 +9,7 @@ import MessageSender = chrome.runtime.MessageSender;
 // Send message to content script
 function sendMessage(msg: Message) {
   if (chrome.tabs && chrome.devtools?.inspectedWindow) {
-    const  { tabId } = chrome.devtools.inspectedWindow;
+    const { tabId } = chrome.devtools.inspectedWindow;
     chrome.tabs.sendMessage(tabId || 0, msg);
   }
 }
@@ -18,7 +18,7 @@ function sendMessage(msg: Message) {
 let refreshListeners: Set<(err: string, data: RefreshMessage | null) => void> =
   new Set();
 export function onGrowthBookData(
-  cb: (err: string, data: RefreshMessage | null) => void
+  cb: (err: string, data: RefreshMessage | null) => void,
 ) {
   refreshListeners.add(cb);
   return () => {
@@ -41,7 +41,7 @@ chrome.runtime.onMessage.addListener(
         cb(msg.error, null);
       });
     }
-  }
+  },
 );
 
 export function requestRefresh() {

--- a/src/devtools/embed_script.ts
+++ b/src/devtools/embed_script.ts
@@ -40,7 +40,7 @@ function onGrowthBookLoad(cb: (gb: GrowthBook) => void) {
       clearTimeout(timer);
       getValidGrowthBookInstance(cb);
     },
-    false
+    false,
   );
 }
 

--- a/src/devtools/init.ts
+++ b/src/devtools/init.ts
@@ -1,5 +1,5 @@
 chrome.devtools.panels.create(
   "GrowthBook",
   "logo192.png",
-  "devtools_panel.html"
+  "devtools_panel.html",
 );

--- a/src/devtools/ui/App.tsx
+++ b/src/devtools/ui/App.tsx
@@ -110,7 +110,7 @@ function App(props: Props) {
 
   const filteredFeatures = features.filter((f) => !q || f.key.includes(q));
   const filteredExperiments = experiments.filter(
-    (e) => !q || e.experiment.key.includes(q)
+    (e) => !q || e.experiment.key.includes(q),
   );
 
   return (

--- a/src/devtools/ui/ClientInfo.tsx
+++ b/src/devtools/ui/ClientInfo.tsx
@@ -12,7 +12,7 @@ export default function ClientInfo(props: ClientInfoProps) {
   const { onCopy: onCopyClientKey, hasCopied: hasCopiedClientKey } =
     useClipboard(props.clientKey);
   const { onCopy: onCopyApiHost, hasCopied: hasCopiedApiHost } = useClipboard(
-    props.apiHost
+    props.apiHost,
   );
   const { onCopy: onCopyRequestUrl, hasCopied: hasCopiedRequestUrl } =
     useClipboard(requestUrl);

--- a/src/devtools/ui/index.tsx
+++ b/src/devtools/ui/index.tsx
@@ -77,5 +77,5 @@ root.render(
     <ChakraProvider>
       <WaitForGrowthBook />
     </ChakraProvider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/options/ApiKeyForm.tsx
+++ b/src/options/ApiKeyForm.tsx
@@ -65,7 +65,7 @@ const ApiKeyForm: FC<{
           {
             "gb-bg-blue-600 hover:gb-bg-blue-500 gb-cursor-pointer": !disabled,
             "gb-bg-gray-200 gb-cursor-wait": disabled,
-          }
+          },
         )}
         value="Submit"
         disabled={disabled ?? false}

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -35,5 +35,5 @@ const root = ReactDOM.createRoot(container!);
 root.render(
   <React.StrictMode>
     <Options />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -39,12 +39,14 @@ const Popup = () => {
         <div className="gb-mb-3 gb-px-3 gb-py-2 gb-border gb-border-gray-200 gb-rounded-lg gb-bg-white">
           <label className="gb-label gb-text-sm">Visual Editor</label>
           <div className="gb-mt-1">
-            To use the visual editor, you must create an experiment in <strong>GrowthBook</strong> and add <strong>Visual Editor</strong> changes.
+            To use the visual editor, you must create an experiment in{" "}
+            <strong>GrowthBook</strong> and add <strong>Visual Editor</strong>{" "}
+            changes.
           </div>
         </div>
 
         <div className="gb-px-3 gb-py-2 gb-border gb-border-gray-200 gb-rounded-lg gb-bg-white">
-        <a
+          <a
             className="gb-flex gb-justify-between gb-items-center hover:gb-underline"
             role="button"
             onClick={() => {
@@ -88,7 +90,7 @@ const root = ReactDOM.createRoot(container!);
 root.render(
   <React.StrictMode>
     <Popup />
-  </React.StrictMode>
+  </React.StrictMode>,
 );
 
 function getOS() {

--- a/src/visual_editor/components/AICopySuggestor.tsx
+++ b/src/visual_editor/components/AICopySuggestor.tsx
@@ -21,7 +21,7 @@ const AICopySuggestor: FC<{
   transformedCopy,
 }) => {
   const [tone, setTone] = useState<"concise" | "energetic" | "humorous" | null>(
-    null
+    null,
   );
   const [generatedCopy, setGeneratedCopy] = useState<string>("");
   const [copy, setCopy] = useState(_copy);
@@ -46,7 +46,7 @@ const AICopySuggestor: FC<{
 
       transformCopy(parentElement.innerHTML, mode);
     },
-    [parentElement, loading, transformCopy, setGeneratedCopy]
+    [parentElement, loading, transformCopy, setGeneratedCopy],
   );
 
   const reset = useCallback(() => {
@@ -82,7 +82,7 @@ const AICopySuggestor: FC<{
             "gb-transition-colors",
             {
               "gb-border-gb": tone,
-            }
+            },
           )}
           style={{ flex: 2, maxHeight: "3rem" }}
         >
@@ -106,7 +106,7 @@ const AICopySuggestor: FC<{
               "gb-transition-colors",
               {
                 "gb-border-gb": tone,
-              }
+              },
             )}
             style={{ width: "1px", height: "13px", zIndex: 30 }}
           ></div>
@@ -124,7 +124,7 @@ const AICopySuggestor: FC<{
               "gb-transition-colors",
               {
                 "gb-border-gb": tone === "concise",
-              }
+              },
             )}
             style={{ width: "33%", top: "4px", left: "17%" }}
           ></div>
@@ -140,7 +140,7 @@ const AICopySuggestor: FC<{
               "gb-transition-colors",
               {
                 "gb-border-gb": tone === "energetic",
-              }
+              },
             )}
             style={{ width: "0px", top: "4px", left: "50%" }}
           ></div>
@@ -158,7 +158,7 @@ const AICopySuggestor: FC<{
               "gb-transition-colors",
               {
                 "gb-border-gb": tone === "humorous",
-              }
+              },
             )}
             style={{ width: "33%", top: "4px", left: "50%" }}
           ></div>
@@ -179,7 +179,7 @@ const AICopySuggestor: FC<{
               "gb-transition-colors",
               {
                 "gb-logo-bg": tone === "concise",
-              }
+              },
             )}
           >
             <button
@@ -189,7 +189,7 @@ const AICopySuggestor: FC<{
                 "gb-flex",
                 "gb-justify-center",
                 "gb-items-center",
-                "gb-rounded-l"
+                "gb-rounded-l",
               )}
               style={{ margin: "1px" }}
               onClick={generateCopy("concise")}
@@ -206,7 +206,7 @@ const AICopySuggestor: FC<{
               "gb-cursor-pointer",
               {
                 "gb-logo-bg": tone === "energetic",
-              }
+              },
             )}
           >
             <button
@@ -215,7 +215,7 @@ const AICopySuggestor: FC<{
                 "gb-flex-1",
                 "gb-flex",
                 "gb-justify-center",
-                "gb-items-center"
+                "gb-items-center",
               )}
               style={{ margin: "1px" }}
               onMouseOver={() => !loading && setTone("energetic")}
@@ -233,7 +233,7 @@ const AICopySuggestor: FC<{
               "gb-cursor-pointer",
               {
                 "gb-logo-bg": tone === "humorous",
-              }
+              },
             )}
           >
             <button
@@ -255,7 +255,7 @@ const AICopySuggestor: FC<{
             {
               "-gb-mt-32": !loading,
               "gb-mt-4": loading,
-            }
+            },
           )}
         >
           <BiLoaderCircle className="gb-animate-spin gb-text-indigo-500" />
@@ -283,7 +283,7 @@ const AICopySuggestor: FC<{
               "gb-mt-2",
               "gb-p-2",
               "gb-rounded",
-              "gb-outline-none"
+              "gb-outline-none",
             )}
             style={{ flex: 2 }}
             value={generatedCopy}
@@ -297,7 +297,7 @@ const AICopySuggestor: FC<{
               "gb-text-white",
               "gb-font-semibold",
               "gb-text-sm",
-              "gb-mt-2"
+              "gb-mt-2",
             )}
             onClick={applyCopy}
           >

--- a/src/visual_editor/components/AttributeEdit.tsx
+++ b/src/visual_editor/components/AttributeEdit.tsx
@@ -155,13 +155,12 @@ const AttributeToken: FC<
     </div>
   );
 };
-
 const AttributeEdit: FC<{
   element: HTMLElement;
   onSave: (attributes: Attribute[]) => void;
 }> = ({ element, onSave }) => {
   const attributes = normalizeAttrs(element.attributes);
-
+  
   const removeAttr = useCallback(
     (name: string) => {
       onSave(attributes.filter((attr) => attr.name !== name));

--- a/src/visual_editor/components/AttributeEdit.tsx
+++ b/src/visual_editor/components/AttributeEdit.tsx
@@ -55,7 +55,7 @@ const EditAttributeInput: FC<{
           onChange={(e) => setName(e.target.value)}
         />
       ) : (
-        <div className="gb-w-12 gb-text-xs gb-text-slate-400 gb-mb-2">
+        <div className="gb-text-xs gb-text-slate-400 gb-mb-2 gb-mr-2">
           {name}
         </div>
       )}
@@ -93,7 +93,7 @@ const AddAttributeInput: FC<{
       }
       onCancel();
     },
-    [_onAdd, onCancel]
+    [_onAdd, onCancel],
   );
   return (
     <>
@@ -123,7 +123,7 @@ const AttributeToken: FC<
       onEdit(attr);
       onCancel();
     },
-    [onEdit, onCancel]
+    [onEdit, onCancel],
   );
   if (isEditing) {
     return (
@@ -137,11 +137,11 @@ const AttributeToken: FC<
   }
   return (
     <div className="gb-flex gb-mb-2 last:gb-mb-0">
-      <div className="gb-w-12 gb-text-xs gb-text-slate-400">{name}</div>
+      <div className="gb-text-xs gb-text-slate-400 gb-mr-2">{name}</div>
 
       <div
         className={clsx(
-          "gb-text-link gb-text-ellipsis gb-overflow-hidden gb-text-sm hover:gb-bg-slate-600"
+          "gb-text-link gb-text-ellipsis gb-overflow-hidden gb-text-sm hover:gb-bg-slate-600",
         )}
         style={{ flex: 2, maxHeight: "3rem" }}
         onClick={() => setIsEditing(true)}
@@ -166,7 +166,7 @@ const AttributeEdit: FC<{
     (name: string) => {
       onSave(attributes.filter((attr) => attr.name !== name));
     },
-    [attributes, onSave]
+    [attributes, onSave],
   );
 
   const addAttr = useCallback(
@@ -174,7 +174,7 @@ const AttributeEdit: FC<{
       const deduped = attributes.filter((a) => a.name !== name);
       onSave([...deduped, { name, value }]);
     },
-    [onSave, attributes]
+    [onSave, attributes],
   );
 
   const editAttr = useCallback(
@@ -183,7 +183,7 @@ const AttributeEdit: FC<{
         ...attributes.map((a) => (a.name === name ? { name, value } : a)),
       ]);
     },
-    [onSave, attributes]
+    [onSave, attributes],
   );
 
   return (

--- a/src/visual_editor/components/BackToGBButton.tsx
+++ b/src/visual_editor/components/BackToGBButton.tsx
@@ -12,7 +12,7 @@ const BackToGBButton: FC<{
       "gb-rounded",
       "gb-text-white",
       "gb-font-semibold",
-      "gb-text-lg"
+      "gb-text-lg",
     )}
     onClick={() => {
       if (experimentUrl) {

--- a/src/visual_editor/components/BackToGBButton.tsx
+++ b/src/visual_editor/components/BackToGBButton.tsx
@@ -5,15 +5,7 @@ const BackToGBButton: FC<{
   experimentUrl: string | null;
 }> = ({ experimentUrl }) => (
   <button
-    className={clsx(
-      "gb-w-full",
-      "gb-p-2",
-      "gb-bg-indigo-800",
-      "gb-rounded",
-      "gb-text-white",
-      "gb-font-semibold",
-      "gb-text-lg",
-    )}
+    className="gb-w-full gb-p-2 gb-bg-indigo-800 hover:gb-bg-indigo-700 gb-rounded gb-text-white gb-font-semibold gb-text-lg gb-transition-colors"
     onClick={() => {
       if (experimentUrl) {
         window.location.href = experimentUrl;

--- a/src/visual_editor/components/BreadcrumbsView.tsx
+++ b/src/visual_editor/components/BreadcrumbsView.tsx
@@ -19,7 +19,7 @@ const BreadcrumbsView: FC<{
   const breadcrumbs = useMemo(() => getBreadcrumbs(element), [element]);
   const children = useMemo(
     () => Array.from(element.children),
-    [element, elementInnerHtml]
+    [element, elementInnerHtml],
   );
 
   const onChildSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -55,11 +55,7 @@ const BreadcrumbsView: FC<{
         <span>
           {" > "}
           <span>
-            <select
-              value={-1}
-              onChange={onChildSelect}
-              className="gb-my-2"
-            >
+            <select value={-1} onChange={onChildSelect} className="gb-my-2">
               <option value={-1}>MORE</option>
               {children.map((child, index) => (
                 <option key={index} value={index}>

--- a/src/visual_editor/components/CSSAttributeEditor/CSSTextInput.tsx
+++ b/src/visual_editor/components/CSSAttributeEditor/CSSTextInput.tsx
@@ -64,7 +64,7 @@ const CSSTextInput: FC<{
             {
               "gb-text-slate-200": isInline,
               "gb-text-slate-400": !isInline,
-            }
+            },
           )}
           style={{ flex: 2, maxHeight: "3rem" }}
           onClick={() => setIsEditing(true)}

--- a/src/visual_editor/components/CSSAttributeEditor/index.tsx
+++ b/src/visual_editor/components/CSSAttributeEditor/index.tsx
@@ -230,7 +230,7 @@ const CSSAttributeEditor: FC<{
         });
       }
     },
-    [elementStyle]
+    [elementStyle],
   );
 
   return (

--- a/src/visual_editor/components/ClassNamesEdit.tsx
+++ b/src/visual_editor/components/ClassNamesEdit.tsx
@@ -79,7 +79,7 @@ const ClassNamesEdit: FC<{
       const newClassNames = new Set([...classNames.split(" ")]);
       _onAdd(Array.from(newClassNames).join(" "));
     },
-    [classNames, _onAdd]
+    [classNames, _onAdd],
   );
 
   return (

--- a/src/visual_editor/components/DOMMutationList.tsx
+++ b/src/visual_editor/components/DOMMutationList.tsx
@@ -126,7 +126,7 @@ const DOMMutationList: FC<{
       }
       removeDomMutation?.(mutation);
     },
-    [removeDomMutation, clearGlobalCss]
+    [removeDomMutation, clearGlobalCss],
   );
 
   return (

--- a/src/visual_editor/components/ElementDetails/DetailsRow.tsx
+++ b/src/visual_editor/components/ElementDetails/DetailsRow.tsx
@@ -73,7 +73,7 @@ const DetailsRow = ({
               "hover:gb-text-slate-100": !readOnly,
               "hover:gb-bg-slate-600": !readOnly,
               "gb-cursor-pointer": !readOnly,
-            }
+            },
           )}
           style={{ flex: 2, maxHeight: "3rem" }}
           onClick={!readOnly ? () => setIsEditing(true) : () => {}}

--- a/src/visual_editor/components/ElementDetails/index.tsx
+++ b/src/visual_editor/components/ElementDetails/index.tsx
@@ -20,6 +20,7 @@ const ElementDetails: FC<{
   const html = element.innerHTML;
   const isHtmlTooLarge = html.length > 100000;
 
+  console.log("html", html);
   return (
     <div className="gb-text-light gb-flex gb-flex-col gb-ml-4">
       <div className="gb-mb-2">

--- a/src/visual_editor/components/ElementDetails/index.tsx
+++ b/src/visual_editor/components/ElementDetails/index.tsx
@@ -20,7 +20,6 @@ const ElementDetails: FC<{
   const html = element.innerHTML;
   const isHtmlTooLarge = html.length > 100000;
 
-  console.log("html", html);
   return (
     <div className="gb-text-light gb-flex gb-flex-col gb-ml-4">
       <div className="gb-mb-2">

--- a/src/visual_editor/components/ErrorDisplay.tsx
+++ b/src/visual_editor/components/ErrorDisplay.tsx
@@ -62,7 +62,6 @@ const ErrorDisplay: FC<ErrorDisplayProps> = ({ error, cspError }) => {
 
 export default (props: ErrorDisplayProps) => {
   const { error, cspError } = props;
-  console.log("error", error);
   const errorContainerRef = useRef<HTMLDivElement | null>(null);
 
   // scroll to error

--- a/src/visual_editor/components/ErrorDisplay.tsx
+++ b/src/visual_editor/components/ErrorDisplay.tsx
@@ -62,6 +62,7 @@ const ErrorDisplay: FC<ErrorDisplayProps> = ({ error, cspError }) => {
 
 export default (props: ErrorDisplayProps) => {
   const { error, cspError } = props;
+  console.log("error", error);
   const errorContainerRef = useRef<HTMLDivElement | null>(null);
 
   // scroll to error

--- a/src/visual_editor/components/FloatingFrame.tsx
+++ b/src/visual_editor/components/FloatingFrame.tsx
@@ -79,15 +79,16 @@ const FloatingFrameEdge = ({
   domRect: DOMRect;
   position: "top" | "right" | "bottom" | "left";
 }) => {
-
-  return <div
-    className={clsx("gb-fixed", "gb-z-front", "gb-border-indigo-600", {
-      "gb-border-t": position === "top" || position === "bottom",
-      "gb-border-l": position === "right" || position === "left",
-    })}
-    style={edgeStyles(domRect)[position]}
-  ></div>
-  };
+  return (
+    <div
+      className={clsx("gb-fixed", "gb-z-front", "gb-border-indigo-600", {
+        "gb-border-t": position === "top" || position === "bottom",
+        "gb-border-l": position === "right" || position === "left",
+      })}
+      style={edgeStyles(domRect)[position]}
+    ></div>
+  );
+};
 
 const FloatingFrame: FC<{
   hideOverlay?: boolean;

--- a/src/visual_editor/components/FloatingFrame.tsx
+++ b/src/visual_editor/components/FloatingFrame.tsx
@@ -78,15 +78,16 @@ const FloatingFrameEdge = ({
 }: {
   domRect: DOMRect;
   position: "top" | "right" | "bottom" | "left";
-}) => (
-  <div
+}) => {
+
+  return <div
     className={clsx("gb-fixed", "gb-z-front", "gb-border-indigo-600", {
       "gb-border-t": position === "top" || position === "bottom",
       "gb-border-l": position === "right" || position === "left",
     })}
     style={edgeStyles(domRect)[position]}
   ></div>
-);
+  };
 
 const FloatingFrame: FC<{
   hideOverlay?: boolean;
@@ -96,7 +97,6 @@ const FloatingFrame: FC<{
   const domRect = useFloatingAnchor(parentElement);
 
   if (!domRect) return null;
-
   return (
     <>
       <FloatingFrameEdge domRect={domRect} position="top" />

--- a/src/visual_editor/components/IDrop.tsx
+++ b/src/visual_editor/components/IDrop.tsx
@@ -26,7 +26,7 @@ const IDrop: FC<{ tooltip: string }> = ({ tooltip }) => {
           {
             "gb-hidden gb-opacity-0": !showTooltip,
             "gb-opacity-100": showTooltip,
-          }
+          },
         )}
       >
         {tooltip}

--- a/src/visual_editor/components/MoveElementHandle.tsx
+++ b/src/visual_editor/components/MoveElementHandle.tsx
@@ -4,8 +4,9 @@ import useFloatingAnchor from "../lib/hooks/useFloatingAnchor";
 
 const MoveElementHandle = forwardRef<
   HTMLDivElement,
-  { parentElement: HTMLElement }
->(function ({ parentElement }, ref) {
+  { parentElement: HTMLElement, onPointerDown: () => void }
+>(function ({ parentElement, onPointerDown}, ref) {
+  
   const domRect = useFloatingAnchor(parentElement);
   if (!domRect) return null;
   if (!parentElement) return null;
@@ -17,6 +18,7 @@ const MoveElementHandle = forwardRef<
         top: domRect.bottom + 8,
         left: domRect.left + domRect.width - 40,
       }}
+      onPointerDown={onPointerDown}
     >
       <RxMove className="gb-w-6 gb-h-6" />
     </div>

--- a/src/visual_editor/components/MoveElementHandle.tsx
+++ b/src/visual_editor/components/MoveElementHandle.tsx
@@ -4,9 +4,8 @@ import useFloatingAnchor from "../lib/hooks/useFloatingAnchor";
 
 const MoveElementHandle = forwardRef<
   HTMLDivElement,
-  { parentElement: HTMLElement, onPointerDown: () => void }
->(function ({ parentElement, onPointerDown}, ref) {
-  
+  { parentElement: HTMLElement; onPointerDown: () => void }
+>(function ({ parentElement, onPointerDown }, ref) {
   const domRect = useFloatingAnchor(parentElement);
   if (!domRect) return null;
   if (!parentElement) return null;

--- a/src/visual_editor/components/ReloadPageButton.tsx
+++ b/src/visual_editor/components/ReloadPageButton.tsx
@@ -26,7 +26,7 @@ const refreshWithParams = ({
         [VARIATION_INDEX_PARAMS_KEY]: variationIndex,
         [AI_ENABLED_PARAMS_KEY]: hasAiEnabled,
       },
-    })
+    }),
   );
 };
 

--- a/src/visual_editor/components/Toolbar.tsx
+++ b/src/visual_editor/components/Toolbar.tsx
@@ -55,7 +55,7 @@ const ToolbarButton = ({
           "hover:gb-bg-slate-600/75": !disabled,
           "gb-bg-slate-700": !disabled && isActive,
           "gb-cursor-not-allowed": disabled,
-        }
+        },
       )}
       onClick={disabled ? () => {} : isActive ? deactivate : activate}
     >

--- a/src/visual_editor/components/VisualEditorSection.tsx
+++ b/src/visual_editor/components/VisualEditorSection.tsx
@@ -29,7 +29,7 @@ const VisualEditorSection: FC<{
             "gb-flex gb-justify-between": onClose,
             "gb-shadow-xl": isExpanded,
             "gb-mb-2": isExpanded,
-          }
+          },
         )}
       >
         <div className="gb-flex gb-items-center gb-relative">
@@ -52,7 +52,7 @@ const VisualEditorSection: FC<{
                 "gb-w-4 gb-h-4 gb-cursor-pointer gb-text-link gb-mx-2",
                 {
                   "gb-rotate-180": !isExpanded,
-                }
+                },
               )}
               onClick={toggleExpanded}
             />

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -93,6 +93,7 @@ const VisualEditor: FC<{}> = () => {
 
   const updateSelectedVariation = useCallback(
     (updates: Partial<VisualEditorVariation>) => {
+      console.log(selectedVariationIndex, "hello what is going on1");
       updateVariationAtIndex(selectedVariationIndex, updates);
     },
     [selectedVariationIndex, updateVariationAtIndex]
@@ -166,22 +167,22 @@ const VisualEditor: FC<{}> = () => {
 
   // Upon any DOM change on the page, we trigger a refresh of visual editor to
   // keep it in sync. We use debounce to limit forceUpdate calls to 1 per 100ms.
-  const [, _forceUpdate] = useReducer((x) => x + 1, 0);
-  const forceUpdate = debounce(() => _forceUpdate(), 100);
+  // const [, _forceUpdate] = useReducer((x) => x + 1, 0);
+  // const forceUpdate = debounce(() => _forceUpdate(), 100);
 
-  useEffect(() => {
-      const observer = new MutationObserver(() =>
-        setTimeout(() => forceUpdate(), 0)
-      );
-      observer.observe(document.body, {
-        attributes: true,
-        childList: true,
-        subtree: true,
-      });
-      return () => {
-        observer.disconnect();
-      }
-  }, []);
+  // useEffect(() => {
+  //     const observer = new MutationObserver(() =>
+  //       setTimeout(() => forceUpdate(), 0)
+  //     );
+  //     observer.observe(document.body, {
+  //       attributes: true,
+  //       childList: true,
+  //       subtree: true,
+  //     });
+  //     return () => {
+  //       observer.disconnect();
+  //     }
+  // }, []);
   //reset inline editing when mode changes
   useEffect(() => {
     resetAndStopInlineEditing();

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -138,7 +138,10 @@ const VisualEditor: FC<{}> = () => {
     updateVariation: updateSelectedVariation  });
 
   const moveHandleRef = useRef<HTMLDivElement | null>(null);
-  const {isDragging} = useDragAndDrop({
+  const [isDragging, setDragging] = useState(false);
+
+
+  const {isDragging: draggingStarted } = useDragAndDrop({
     isEnabled: mode === "edit" && !isInlineEditing,
     elementToDrag: isInlineEditing? null : elementUnderEdit,
     addDomMutation,
@@ -148,7 +151,17 @@ const VisualEditor: FC<{}> = () => {
     hasSDK,
     sdkVersion: version,
   });  
-
+  // wait for 1 second before setting dragging to true
+  useEffect(() => {
+    if (draggingStarted) {
+      const timeout = setTimeout(() => {
+        setDragging(true);
+      }, 500);
+      return () => clearTimeout(timeout);
+    } else {
+      setDragging(false);
+    }
+  }, [draggingStarted]);
 
   const selectedVariationTotalChangesLength = useMemo(
     () =>
@@ -374,7 +387,7 @@ const VisualEditor: FC<{}> = () => {
         />
       ) : null}
       {/** Overlays for highlighting hovered elements **/}
-      {mode === "edit" && !isDragging && !isInlineEditing ? (
+      {mode === "edit" && !isDragging ? (
         <>
           <FloatingFrame parentElement={highlightedElement} />
           <SelectorDisplay parentElement={highlightedElement} />

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -1,4 +1,4 @@
-import { debounce, remove } from "lodash";
+import { debounce } from "lodash";
 import React, {
   FC,
   useCallback,
@@ -138,7 +138,6 @@ const VisualEditor: FC<{}> = () => {
     updateVariation: updateSelectedVariation  });
 
   const moveHandleRef = useRef<HTMLDivElement | null>(null);
-  console.log( mode === "edit", isInlineEditing, elementUnderEdit);
   const {isDragging} = useDragAndDrop({
     isEnabled: mode === "edit" && !isInlineEditing,
     elementToDrag: isInlineEditing? null : elementUnderEdit,
@@ -168,12 +167,9 @@ const VisualEditor: FC<{}> = () => {
   // Upon any DOM change on the page, we trigger a refresh of visual editor to
   // keep it in sync. We use debounce to limit forceUpdate calls to 1 per 100ms.
   const [, _forceUpdate] = useReducer((x) => x + 1, 0);
-  const forceUpdate = debounce(()=>{
-      _forceUpdate();
-  }, 100);
+  const forceUpdate = debounce(() => _forceUpdate(), 100);
 
   useEffect(() => {
-    // we need to disable mutation observer when contentEditable is active to prevent overriding user changes){
       const observer = new MutationObserver(() =>
         setTimeout(() => forceUpdate(), 0)
       );
@@ -355,7 +351,7 @@ const VisualEditor: FC<{}> = () => {
             }
           />
          {!elementUnderEdit && <SelectorDisplay parentElement={elementUnderEdit} />}
-          {elementUnderEditMutations.length > 0 ? (
+          {elementUnderEditMutations.length > 0 && !!elementUnderEdit ? (
             <FloatingUndoButton
               parentElement={elementUnderEdit}
               undo={() =>{

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -129,32 +129,27 @@ const VisualEditor: FC<{}> = () => {
     setDomMutations,
     ignoreClassNames,
     setIgnoreClassNames,
-    pauseInlineEditing,
-    resumeInlineEditing,
     stopInlineEditing,
-    resetAndStopInlineEditing
+    resetAndStopInlineEditing,
+    isInlineEditing,
   } = useEditMode({
     isEnabled: mode === "edit",
     variation: selectedVariation,
     updateVariation: updateSelectedVariation  });
 
   const moveHandleRef = useRef<HTMLDivElement | null>(null);
-
-  const { isDragging } = useDragAndDrop({
-    isEnabled: mode === "edit",
-    elementToDrag: elementUnderEdit,
+  console.log( mode === "edit", isInlineEditing, elementUnderEdit);
+  const {isDragging} = useDragAndDrop({
+    isEnabled: mode === "edit" && !isInlineEditing,
+    elementToDrag: isInlineEditing? null : elementUnderEdit,
     addDomMutation,
     elementUnderEditMutations,
     setDomMutations,
     moveHandleRef,
     hasSDK,
     sdkVersion: version,
-  });
+  });  
 
-  // stop inline editing when dragging
-  useEffect(() => {
-      isDragging? pauseInlineEditing(): resumeInlineEditing();
-  }, [isDragging]);
 
   const selectedVariationTotalChangesLength = useMemo(
     () =>
@@ -349,7 +344,7 @@ const VisualEditor: FC<{}> = () => {
       </VisualEditorPane>
 
       {/** Overlays for highlighting selected elements **/}
-      {mode === "edit" && elementUnderEdit && !isDragging ? (
+      {mode === "edit" && elementUnderEdit && !isDragging  ? (
         <>
           <FloatingFrame
             hideOverlay={isDragging}
@@ -359,7 +354,7 @@ const VisualEditor: FC<{}> = () => {
             }
             }
           />
-          <SelectorDisplay parentElement={elementUnderEdit} />
+         {!elementUnderEdit && <SelectorDisplay parentElement={elementUnderEdit} />}
           {elementUnderEditMutations.length > 0 ? (
             <FloatingUndoButton
               parentElement={elementUnderEdit}
@@ -376,14 +371,15 @@ const VisualEditor: FC<{}> = () => {
           ) : null}
         </>
       ) : null}
-      {mode === "edit" && elementUnderEdit ? (
+      {mode === "edit" && elementUnderEdit && !isInlineEditing ? (
         <MoveElementHandle
           ref={moveHandleRef}
           parentElement={elementUnderEdit}
+          onPointerDown={() => stopInlineEditing()}
         />
       ) : null}
       {/** Overlays for highlighting hovered elements **/}
-      {mode === "edit" && !isDragging ? (
+      {mode === "edit" && !isDragging && !isInlineEditing ? (
         <>
           <FloatingFrame parentElement={highlightedElement} />
           <SelectorDisplay parentElement={highlightedElement} />

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -179,7 +179,6 @@ const VisualEditor: FC<{}> = () => {
 
   useEffect(() => {
     // we need to disable mutation observer when contentEditable is active to prevent overriding user changes){
-      console.log("Mutation observer enabled");
       const observer = new MutationObserver(() =>
         setTimeout(() => forceUpdate(), 0)
       );
@@ -189,7 +188,6 @@ const VisualEditor: FC<{}> = () => {
         subtree: true,
       });
       return () => {
-        console.log("Mutation observer disconnected");
         observer.disconnect();
       }
   }, []);
@@ -367,11 +365,10 @@ const VisualEditor: FC<{}> = () => {
               parentElement={elementUnderEdit}
               undo={() =>{
                 const lastMutation = elementUnderEditMutations[elementUnderEditMutations.length - 1];
-                console.log()
                 if (lastMutation.value === elementUnderEdit.innerHTML) {
-                    resetAndStopInlineEditing();
                     removeDomMutation(lastMutation);
-                } else if (isGlobalObserverPaused()) {
+                }
+                if (isGlobalObserverPaused()) {
                   resetAndStopInlineEditing();
                 }
               }}

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -1,4 +1,4 @@
-import { debounce } from "lodash";
+import { debounce, remove } from "lodash";
 import React, {
   FC,
   useCallback,
@@ -47,7 +47,7 @@ import DebugPanel from "./components/DebugPanel";
 
 import VisualEditorCss from "./shadowDom.css";
 import "./targetPage.css";
-import { isGlobalObserverPaused } from "dom-mutator";
+import { isGlobalObserverPaused, resumeGlobalObserver } from "dom-mutator";
 
 const VisualEditor: FC<{}> = () => {
   const { x, y, setX, setY, parentStyles } = useFixedPositioning({
@@ -367,11 +367,11 @@ const VisualEditor: FC<{}> = () => {
               parentElement={elementUnderEdit}
               undo={() =>{
                 const lastMutation = elementUnderEditMutations[elementUnderEditMutations.length - 1];
+                console.log()
                 if (lastMutation.value === elementUnderEdit.innerHTML) {
+                    resetAndStopInlineEditing();
                     removeDomMutation(lastMutation);
-
-                }
-                if (isGlobalObserverPaused()) {
+                } else if (isGlobalObserverPaused()) {
                   resetAndStopInlineEditing();
                 }
               }}

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -186,7 +186,6 @@ const VisualEditor: FC<{}> = () => {
   useEffect(() => {
     resetAndStopInlineEditing();
   }, [mode] );
-
   return (
     <>
       <VisualEditorPane style={parentStyles}>

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -95,7 +95,7 @@ const VisualEditor: FC<{}> = () => {
     (updates: Partial<VisualEditorVariation>) => {
       updateVariationAtIndex(selectedVariationIndex, updates);
     },
-    [selectedVariationIndex, updateVariationAtIndex]
+    [selectedVariationIndex, updateVariationAtIndex],
   );
 
   const { globalCss, setGlobalCss } = useGlobalCSS({
@@ -135,22 +135,22 @@ const VisualEditor: FC<{}> = () => {
   } = useEditMode({
     isEnabled: mode === "edit",
     variation: selectedVariation,
-    updateVariation: updateSelectedVariation  });
+    updateVariation: updateSelectedVariation,
+  });
 
   const moveHandleRef = useRef<HTMLDivElement | null>(null);
   const [isDragging, setDragging] = useState(false);
 
-
-  const {isDragging: draggingStarted } = useDragAndDrop({
+  const { isDragging: draggingStarted } = useDragAndDrop({
     isEnabled: mode === "edit" && !isInlineEditing,
-    elementToDrag: isInlineEditing? null : elementUnderEdit,
+    elementToDrag: isInlineEditing ? null : elementUnderEdit,
     addDomMutation,
     elementUnderEditMutations,
     setDomMutations,
     moveHandleRef,
     hasSDK,
     sdkVersion: version,
-  });  
+  });
   // wait for 1 second before setting dragging to true
   useEffect(() => {
     if (draggingStarted) {
@@ -168,7 +168,7 @@ const VisualEditor: FC<{}> = () => {
       (selectedVariation?.domMutations ?? []).length +
       (selectedVariation?.js ? 1 : 0) +
       (selectedVariation?.css ? 1 : 0),
-    [selectedVariation]
+    [selectedVariation],
   );
 
   useEffect(() => {
@@ -183,22 +183,22 @@ const VisualEditor: FC<{}> = () => {
   const forceUpdate = debounce(() => _forceUpdate(), 100);
 
   useEffect(() => {
-      const observer = new MutationObserver(() =>
-        setTimeout(() => forceUpdate(), 0)
-      );
-      observer.observe(document.body, {
-        attributes: true,
-        childList: true,
-        subtree: true,
-      });
-      return () => {
-        observer.disconnect();
-      }
+    const observer = new MutationObserver(() =>
+      setTimeout(() => forceUpdate(), 0),
+    );
+    observer.observe(document.body, {
+      attributes: true,
+      childList: true,
+      subtree: true,
+    });
+    return () => {
+      observer.disconnect();
+    };
   }, []);
   //reset inline editing when mode changes
   useEffect(() => {
     resetAndStopInlineEditing();
-  }, [mode] );
+  }, [mode]);
   return (
     <>
       <VisualEditorPane style={parentStyles}>
@@ -352,24 +352,28 @@ const VisualEditor: FC<{}> = () => {
       </VisualEditorPane>
 
       {/** Overlays for highlighting selected elements **/}
-      {mode === "edit" && elementUnderEdit && !isDragging  ? (
+      {mode === "edit" && elementUnderEdit && !isDragging ? (
         <>
           <FloatingFrame
             hideOverlay={isDragging}
             parentElement={elementUnderEdit}
             clearSelectedElement={() => {
               stopInlineEditing();
-            }
-            }
+            }}
           />
-         {!elementUnderEdit && <SelectorDisplay parentElement={elementUnderEdit} />}
+          {!elementUnderEdit && (
+            <SelectorDisplay parentElement={elementUnderEdit} />
+          )}
           {elementUnderEditMutations.length > 0 && !!elementUnderEdit ? (
             <FloatingUndoButton
               parentElement={elementUnderEdit}
-              undo={() =>{
-                const lastMutation = elementUnderEditMutations[elementUnderEditMutations.length - 1];
+              undo={() => {
+                const lastMutation =
+                  elementUnderEditMutations[
+                    elementUnderEditMutations.length - 1
+                  ];
                 if (lastMutation.value === elementUnderEdit.innerHTML) {
-                    removeDomMutation(lastMutation);
+                  removeDomMutation(lastMutation);
                 }
                 if (isGlobalObserverPaused()) {
                   resetAndStopInlineEditing();
@@ -417,7 +421,7 @@ if (shadowRoot) {
 document.body.appendChild(container);
 
 const root = ReactDOM.createRoot(
-  shadowRoot.querySelector("#visual-editor-root")!
+  shadowRoot.querySelector("#visual-editor-root")!,
 );
 
 root.render(<VisualEditor />);

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -93,7 +93,6 @@ const VisualEditor: FC<{}> = () => {
 
   const updateSelectedVariation = useCallback(
     (updates: Partial<VisualEditorVariation>) => {
-      console.log(selectedVariationIndex, "hello what is going on1");
       updateVariationAtIndex(selectedVariationIndex, updates);
     },
     [selectedVariationIndex, updateVariationAtIndex]
@@ -167,22 +166,22 @@ const VisualEditor: FC<{}> = () => {
 
   // Upon any DOM change on the page, we trigger a refresh of visual editor to
   // keep it in sync. We use debounce to limit forceUpdate calls to 1 per 100ms.
-  // const [, _forceUpdate] = useReducer((x) => x + 1, 0);
-  // const forceUpdate = debounce(() => _forceUpdate(), 100);
+  const [, _forceUpdate] = useReducer((x) => x + 1, 0);
+  const forceUpdate = debounce(() => _forceUpdate(), 100);
 
-  // useEffect(() => {
-  //     const observer = new MutationObserver(() =>
-  //       setTimeout(() => forceUpdate(), 0)
-  //     );
-  //     observer.observe(document.body, {
-  //       attributes: true,
-  //       childList: true,
-  //       subtree: true,
-  //     });
-  //     return () => {
-  //       observer.disconnect();
-  //     }
-  // }, []);
+  useEffect(() => {
+      const observer = new MutationObserver(() =>
+        setTimeout(() => forceUpdate(), 0)
+      );
+      observer.observe(document.body, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+      });
+      return () => {
+        observer.disconnect();
+      }
+  }, []);
   //reset inline editing when mode changes
   useEffect(() => {
     resetAndStopInlineEditing();

--- a/src/visual_editor/lib/getSelector.ts
+++ b/src/visual_editor/lib/getSelector.ts
@@ -2,7 +2,7 @@ import { finder } from "@medv/finder";
 
 export default function getSelector(
   element: Element,
-  options?: { ignoreClassNames: boolean }
+  options?: { ignoreClassNames: boolean },
 ) {
   let selector = "";
   try {

--- a/src/visual_editor/lib/hooks/useAiCopySuggestion.ts
+++ b/src/visual_editor/lib/hooks/useAiCopySuggestion.ts
@@ -63,7 +63,7 @@ const useAiCopySuggestion: UseAiCopySuggestionHook = (visualChangesetId) => {
 
       window.postMessage(transformCopyMessage, window.location.origin);
     },
-    [visualChangesetId]
+    [visualChangesetId],
   );
 
   return {

--- a/src/visual_editor/lib/hooks/useDragAndDrop.ts
+++ b/src/visual_editor/lib/hooks/useDragAndDrop.ts
@@ -16,6 +16,7 @@ type UseDragAndDropHook = (args: {
   sdkVersion: string | undefined;
 }) => {
   isDragging: boolean;
+  removeDragListeners: () => void;
 };
 
 const useDragAndDrop: UseDragAndDropHook = ({
@@ -132,6 +133,12 @@ const useDragAndDrop: UseDragAndDropHook = ({
     },
     [isDragging, elementToDrag, setDragDestination]
   );
+  const removeDragListeners = () => {
+    document.removeEventListener("pointerdown", onPointerDown, true);
+    document.removeEventListener("pointerup", onPointerUp, true);
+    document.removeEventListener("pointermove", onPointerMove, true);
+    setIsDragging(false);
+  };
 
   useEffect(() => {
     if (!isEnabled || !elementToDrag) return;
@@ -175,7 +182,7 @@ const useDragAndDrop: UseDragAndDropHook = ({
     moveHandleRef.current,
   ]);
 
-  return { isDragging };
+  return { isDragging, removeDragListeners };
 };
 
 export default useDragAndDrop;

--- a/src/visual_editor/lib/hooks/useDragAndDrop.ts
+++ b/src/visual_editor/lib/hooks/useDragAndDrop.ts
@@ -59,7 +59,7 @@ const useDragAndDrop: UseDragAndDropHook = ({
       // if the user is clicking on an already selected element, we begin dragging
       if (elementToDrag?.contains(element)) setIsDragging(true);
     },
-    [elementToDrag, setIsDragging]
+    [elementToDrag, setIsDragging],
   );
 
   const onMoveHandlerPointerDown = useCallback(
@@ -68,7 +68,7 @@ const useDragAndDrop: UseDragAndDropHook = ({
       event.stopPropagation();
       setIsDragging(true);
     },
-    [setIsDragging]
+    [setIsDragging],
   );
 
   const onPointerUp = useCallback(
@@ -108,7 +108,7 @@ const useDragAndDrop: UseDragAndDropHook = ({
       setDragDestination(null);
       draggingTeardown();
     },
-    [isDragging, elementToDrag, dragDestination, addDomMutation]
+    [isDragging, elementToDrag, dragDestination, addDomMutation],
   );
 
   const onPointerMove = useCallback(
@@ -130,7 +130,7 @@ const useDragAndDrop: UseDragAndDropHook = ({
           siblingElement: draggedToSibling,
         });
     },
-    [isDragging, elementToDrag, setDragDestination]
+    [isDragging, elementToDrag, setDragDestination],
   );
 
   useEffect(() => {
@@ -149,7 +149,7 @@ const useDragAndDrop: UseDragAndDropHook = ({
       moveHandlerElem.addEventListener(
         "pointerdown",
         onMoveHandlerPointerDown,
-        true
+        true,
       );
     }
 
@@ -162,7 +162,7 @@ const useDragAndDrop: UseDragAndDropHook = ({
         moveHandlerElem.removeEventListener(
           "pointerdown",
           onMoveHandlerPointerDown,
-          true
+          true,
         );
       }
     };

--- a/src/visual_editor/lib/hooks/useDragAndDrop.ts
+++ b/src/visual_editor/lib/hooks/useDragAndDrop.ts
@@ -16,7 +16,6 @@ type UseDragAndDropHook = (args: {
   sdkVersion: string | undefined;
 }) => {
   isDragging: boolean;
-  removeDragListeners: () => void;
 };
 
 const useDragAndDrop: UseDragAndDropHook = ({
@@ -133,12 +132,6 @@ const useDragAndDrop: UseDragAndDropHook = ({
     },
     [isDragging, elementToDrag, setDragDestination]
   );
-  const removeDragListeners = () => {
-    document.removeEventListener("pointerdown", onPointerDown, true);
-    document.removeEventListener("pointerup", onPointerUp, true);
-    document.removeEventListener("pointermove", onPointerMove, true);
-    setIsDragging(false);
-  };
 
   useEffect(() => {
     if (!isEnabled || !elementToDrag) return;
@@ -182,7 +175,7 @@ const useDragAndDrop: UseDragAndDropHook = ({
     moveHandleRef.current,
   ]);
 
-  return { isDragging, removeDragListeners };
+  return { isDragging };
 };
 
 export default useDragAndDrop;

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -158,8 +158,8 @@ const useEditMode: UseEditModeHook = ({
 
   const setInnerHTML = useCallback(
     (html: string) => {
-      if(elementUnderEdit)
-        if(variation?.domMutations.length === 0){
+      if(!elementUnderEdit) return;
+      if(variation?.domMutations.length === 0){
 
          elementUnderEdit.innerText = elementUnderEditCopy;
         }
@@ -335,7 +335,7 @@ const useEditMode: UseEditModeHook = ({
     
     if (!elementUnderEdit) return;
     elementUnderEdit.removeAttribute("contenteditable");
-    elementUnderEdit.removeEventListener("keydown", ()=>{});
+    elementUnderEdit.removeEventListener("keydown", setInnerHTMLOnInlineEdit);
     if(!isInlineEditing) setElementUnderEdit(null);
     setIsInlineEditing(false);
   }
@@ -343,6 +343,7 @@ const useEditMode: UseEditModeHook = ({
   const stopInlineEditing = () => {
     if (!elementUnderEdit) return;
     const html = elementUnderEdit.innerHTML;
+    if(html === elementUnderEditCopy) return;
     setInnerHTML(html);
     resumeGlobalObserver();
     elementUnderEdit.removeAttribute("contenteditable");
@@ -395,7 +396,7 @@ const setInnerHTMLOnInlineEdit = (event: KeyboardEvent) => {
       range.collapse(false);
       sel?.removeAllRanges();
       sel?.addRange(range);
-      elementUnderEdit?.addEventListener("keydown", (e: KeyboardEvent) =>{setInnerHTMLOnInlineEdit(e)}, false);
+      elementUnderEdit?.addEventListener("keydown", setInnerHTMLOnInlineEdit, false);
     } else {
       setIsInlineEditing(false);
     }

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -78,7 +78,7 @@ const useEditMode: UseEditModeHook = ({
   const [elementUnderEdit, setElementUnderEdit] = useState<HTMLElement | null>(
     null
   );
-  const [currentElement, setCurrentElement] = useState<HTMLElement | null>(
+  const [currentElement,] = useState<HTMLElement | null>(
     null
   );
   const [ignoreClassNames, setIgnoreClassNames] = useState(false);
@@ -122,18 +122,7 @@ const useEditMode: UseEditModeHook = ({
     );
     const text = parsed.body.textContent || "";
     return text.trim();
-  }, [currentElement]);
-
-  const currentElementUnderEditCopy = useMemo(() => {
-    if (!elementUnderEdit){ 
-      return ""
-    }
-    console.log(elementUnderEdit.textContent, "elementUnderEdit in memo");
-    // ignore when selected is simply wrapper of another element
-    if (elementUnderEdit.innerHTML.startsWith("<")) return "";
-
-    return elementUnderEdit.textContent || "";
-  }, [elementUnderEdit, currentElement, variation]);
+  }, [currentElement, variation]);
   
 
   const addDomMutations = useCallback(
@@ -183,8 +172,8 @@ const useEditMode: UseEditModeHook = ({
     (html: string) => {
       if(elementUnderEdit)
         if(variation?.domMutations.length === 0){
-          console.log("setting innerHTML", currentElementUnderEditCopy);
-         elementUnderEdit.innerHTML = currentElementUnderEditCopy;
+          console.log("setting innerHTML", elementUnderEditCopy);
+         elementUnderEdit.innerHTML = elementUnderEditCopy;
         }
       addDomMutations([
         {
@@ -350,7 +339,7 @@ const useEditMode: UseEditModeHook = ({
   const resetAndStopInlineEditing = () => {
     resumeGlobalObserver();
     if(variation?.domMutations.length === 0 && elementUnderEdit){
-      elementUnderEdit.innerHTML = currentElementUnderEditCopy;
+      elementUnderEdit.innerHTML = elementUnderEditCopy;
     }
 
     runMutations(variation?.domMutations);
@@ -461,7 +450,6 @@ const setInnerHTMLOnInlineEdit = (event: KeyboardEvent) => {
       if (element.id === CONTAINER_ID) return;
     
       setElementUnderEdit(element);
-      setCurrentElement(element);
       setInlineEditOnElement(element);
       event.preventDefault();
       event.stopPropagation();

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -440,13 +440,14 @@ const useEditMode: UseEditModeHook = ({
         setIsInlineEditing(false);
       }
     };
+
     const onPointerMove = throttle((event: MouseEvent) => {
       if (elementUnderEdit) return;
- 
+
       const { clientX: x, clientY: y } = event;
-      let domNode = document.elementFromPoint(x, y);
+      let domNode: Element | null = document.elementFromPoint(x, y);
       const tagType = domNode?.tagName.toLowerCase();
-      if (tagType && ["b","i", "u"].includes(tagType)) {
+      if (tagType && ["b", "i", "u"].includes(tagType)) {
         domNode = domNode?.parentElement || null;
       }
       // return early if we are over the visual editor itself (e.g. frame)
@@ -469,12 +470,13 @@ const useEditMode: UseEditModeHook = ({
       if (elementUnderEdit) return;
       if (elementUnderEdit === element) return;
 
-      // don't intercept cilcks on the visual editor itself
+      // don't intercept clicks on the visual editor itself
       if (element.id === CONTAINER_ID) return;
 
       event.preventDefault();
       event.stopPropagation();
     };
+
     const setCursorForInlineEditing = (element: HTMLElement) => {
       if (!element) return;
       const canInlineEdit = canInlineEditElement(element);
@@ -487,15 +489,15 @@ const useEditMode: UseEditModeHook = ({
       if (event.detail === 1) {
         let element = event.target as HTMLElement;
         const tagType = element?.tagName.toLowerCase();
-          if (tagType && ["b","i", "u"].includes(tagType)) {
+          if (tagType && ["b", "i", "u"].includes(tagType)) {
             element = element?.parentElement as HTMLElement;
           }
         if(!element) return;
         if (isInlineEditing) return;
-        // don't intercept cilcks on the visual editor itself
+        // don't intercept clicks on the visual editor itself
         if (element.id === CONTAINER_ID) return;
 
-        //need to set inline editing true before setting element under edit if it is not inline editing we revert the changes
+        // need to set inline editing true before setting element under edit. if it is not inline editing we revert the changes
         if (!elementUnderEdit) {
           setElementUnderEdit(element);
         }

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -117,7 +117,6 @@ const useEditMode: UseEditModeHook = ({
     (domMutations: DeclarativeMutation[]) => {
       if (!variation || !updateVariation) return;
       const newDomMutations =  [...variation.domMutations, ...domMutations];
-      console.log("how many mutations");
       updateVariation({
         domMutations: newDomMutations,
       });
@@ -164,7 +163,6 @@ const useEditMode: UseEditModeHook = ({
 
          elementUnderEdit.innerText = elementUnderEditCopy;
         }
-        console.log("setting inner html");
       addDomMutations([
         {
           action: "set",

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -1,6 +1,6 @@
 import mutate, { DeclarativeMutation, isGlobalObserverPaused, pauseGlobalObserver,resumeGlobalObserver } from "dom-mutator";
 import { useRef, useMemo, useCallback, useState, useEffect } from "react";
-import { first, set, throttle } from "lodash";
+import { throttle } from "lodash";
 import { Attribute } from "../../components/AttributeEdit";
 import { CONTAINER_ID } from "../..";
 import getSelector from "../getSelector";

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -1,4 +1,9 @@
-import mutate, { DeclarativeMutation, isGlobalObserverPaused, pauseGlobalObserver,resumeGlobalObserver } from "dom-mutator";
+import mutate, {
+  DeclarativeMutation,
+  isGlobalObserverPaused,
+  pauseGlobalObserver,
+  resumeGlobalObserver,
+} from "dom-mutator";
 import { useRef, useMemo, useCallback, useState, useEffect } from "react";
 import { throttle } from "lodash";
 import { Attribute } from "../../components/AttributeEdit";
@@ -66,7 +71,7 @@ const useEditMode: UseEditModeHook = ({
   updateVariation,
 }) => {
   const [elementUnderEdit, setElementUnderEdit] = useState<HTMLElement | null>(
-    null
+    null,
   );
   const [isInlineEditing, setIsInlineEditing] = useState(false);
   const [ignoreClassNames, setIgnoreClassNames] = useState(false);
@@ -74,7 +79,7 @@ const useEditMode: UseEditModeHook = ({
     useState<HTMLElement | null>(null);
   const clearElementUnderEdit = useCallback(
     () => setElementUnderEdit(null),
-    [setElementUnderEdit]
+    [setElementUnderEdit],
   );
   const elementUnderEditSelector = useMemo(
     () =>
@@ -83,7 +88,7 @@ const useEditMode: UseEditModeHook = ({
             ignoreClassNames,
           })
         : "",
-    [elementUnderEdit, ignoreClassNames]
+    [elementUnderEdit, ignoreClassNames],
   );
   const highlightedElementSelector = useMemo(
     () =>
@@ -92,13 +97,13 @@ const useEditMode: UseEditModeHook = ({
             ignoreClassNames,
           })
         : "",
-    [highlightedElement, ignoreClassNames]
+    [highlightedElement, ignoreClassNames],
   );
 
   const elementUnderEditCopy = useMemo(() => {
-    if (!elementUnderEdit){ 
-      return ""
-    };
+    if (!elementUnderEdit) {
+      return "";
+    }
     // ignore when selected is simply wrapper of another element
     if (elementUnderEdit.innerHTML.startsWith("<")) return "";
     // hard-limit on text length
@@ -106,16 +111,16 @@ const useEditMode: UseEditModeHook = ({
     const parser = new DOMParser();
     const parsed = parser.parseFromString(
       elementUnderEdit.innerHTML,
-      "text/html"
+      "text/html",
     );
     const text = parsed.body.textContent || "";
     return text.trim();
   }, [elementUnderEdit, variation]);
 
   const elementUnderEditHTML = useMemo(() => {
-    if (!elementUnderEdit){ 
-      return ""
-    };
+    if (!elementUnderEdit) {
+      return "";
+    }
     // ignore when selected is simply wrapper of another element
     if (elementUnderEdit.innerHTML.startsWith("<")) return "";
     // hard-limit on text length
@@ -123,38 +128,37 @@ const useEditMode: UseEditModeHook = ({
 
     return elementUnderEdit.innerHTML;
   }, [elementUnderEdit, variation]);
-  
 
   const addDomMutations = useCallback(
     (domMutations: DeclarativeMutation[]) => {
       if (!variation || !updateVariation) return;
-      const newDomMutations =  [...variation.domMutations, ...domMutations];
+      const newDomMutations = [...variation.domMutations, ...domMutations];
       updateVariation({
         domMutations: newDomMutations,
       });
       setHighlightedElement(null);
     },
-    [variation, updateVariation]
+    [variation, updateVariation],
   );
 
   const addDomMutation = useCallback(
     (domMutation: DeclarativeMutation) => {
       addDomMutations([domMutation]);
     },
-    [addDomMutations]
+    [addDomMutations],
   );
 
   const removeDomMutations = useCallback(
     (mutations: DeclarativeMutation[]) => {
       if (!variation || !updateVariation) return;
       const newDomMutations = variation.domMutations.filter(
-        (m) => !mutations.includes(m)
+        (m) => !mutations.includes(m),
       );
       updateVariation({
-        domMutations:newDomMutations
+        domMutations: newDomMutations,
       });
     },
-    [updateVariation, variation]
+    [updateVariation, variation],
   );
 
   const setDomMutations = useCallback(
@@ -165,16 +169,15 @@ const useEditMode: UseEditModeHook = ({
       });
     },
 
-    [updateVariation, variation]
+    [updateVariation, variation],
   );
 
   const setInnerHTML = useCallback(
     (html: string) => {
-      if(!elementUnderEdit) return;
-      if(variation?.domMutations.length === 0){
-
-         elementUnderEdit.innerHTML = elementUnderEditHTML;
-        }
+      if (!elementUnderEdit) return;
+      if (variation?.domMutations.length === 0) {
+        elementUnderEdit.innerHTML = elementUnderEditHTML;
+      }
       addDomMutations([
         {
           action: "set",
@@ -184,14 +187,14 @@ const useEditMode: UseEditModeHook = ({
         },
       ]);
     },
-    [elementUnderEditSelector, addDomMutations]
+    [elementUnderEditSelector, addDomMutations],
   );
 
   const undoInnerHTMLMutations = useMemo(() => {
     const htmlMutations = (variation?.domMutations ?? []).filter(
       (mutation) =>
         mutation.attribute === "html" &&
-        mutation.selector === elementUnderEditSelector
+        mutation.selector === elementUnderEditSelector,
     );
     if (htmlMutations.length === 0) return;
     return () => {
@@ -206,10 +209,10 @@ const useEditMode: UseEditModeHook = ({
       const removed = existing.filter(
         (e) =>
           !attrs.find((a) => a.name === e.name) &&
-          !IGNORED_ATTRS.includes(e.name)
+          !IGNORED_ATTRS.includes(e.name),
       );
       const changed = attrs.filter(
-        (attr) => attr.value !== elementUnderEdit.getAttribute(attr.name)
+        (attr) => attr.value !== elementUnderEdit.getAttribute(attr.name),
       );
       removed.forEach((attr) => {
         addDomMutations([
@@ -232,7 +235,7 @@ const useEditMode: UseEditModeHook = ({
         ]);
       });
     },
-    [elementUnderEdit, addDomMutations, elementUnderEditSelector]
+    [elementUnderEdit, addDomMutations, elementUnderEditSelector],
   );
 
   const addClassNames = useCallback(
@@ -244,10 +247,10 @@ const useEditMode: UseEditModeHook = ({
           attribute: "class",
           value: className,
           selector: elementUnderEditSelector,
-        }))
+        })),
       );
     },
-    [elementUnderEditSelector, addDomMutations]
+    [elementUnderEditSelector, addDomMutations],
   );
 
   const removeClassNames = useCallback(
@@ -262,7 +265,7 @@ const useEditMode: UseEditModeHook = ({
         },
       ]);
     },
-    [elementUnderEditSelector, addDomMutations]
+    [elementUnderEditSelector, addDomMutations],
   );
 
   const setCSS = useCallback(
@@ -277,7 +280,7 @@ const useEditMode: UseEditModeHook = ({
         },
       ]);
     },
-    [elementUnderEditSelector, addDomMutations]
+    [elementUnderEditSelector, addDomMutations],
   );
 
   const elementUnderEditMutations = useMemo(
@@ -285,107 +288,109 @@ const useEditMode: UseEditModeHook = ({
       variation?.domMutations.filter((m) =>
         elementUnderEdit && elementUnderEditSelector
           ? m.selector === elementUnderEditSelector
-          : true
+          : true,
       ) ?? [],
-    [elementUnderEdit, variation, elementUnderEditSelector]
+    [elementUnderEdit, variation, elementUnderEditSelector],
   );
 
   const removeDomMutation = useCallback(
     (mutation: DeclarativeMutation) => {
       removeDomMutations([mutation]);
     },
-    [removeDomMutations]
+    [removeDomMutations],
   );
 
   // upon every DOM mutation, we revert all changes and replay them to ensure
   // that the DOM is in the correct state
   const mutateRevert = useRef<(() => void) | null>(null);
-  
-  const runMutations = (domMutations?: VisualEditorVariation["domMutations"]) => {
-     // run reverts if they exist
-      if(!isGlobalObserverPaused()){
-        if (mutateRevert?.current) mutateRevert.current();
-      }
-      const revertCallbacks: Array<() => void> = [];
-      const stopCallbacks: Array<() => void> = [];
-      domMutations?.forEach((mutation) => {
-        const controller = mutate.declarative(mutation);
-        revertCallbacks.push(controller.revert);
-      });
-      if(!isGlobalObserverPaused()){
-        mutateRevert.current = () => {
-          revertCallbacks.reverse().forEach((c) => c());
-        }
-      }
+
+  const runMutations = (
+    domMutations?: VisualEditorVariation["domMutations"],
+  ) => {
+    // run reverts if they exist
+    if (!isGlobalObserverPaused()) {
+      if (mutateRevert?.current) mutateRevert.current();
     }
+    const revertCallbacks: Array<() => void> = [];
+    const stopCallbacks: Array<() => void> = [];
+    domMutations?.forEach((mutation) => {
+      const controller = mutate.declarative(mutation);
+      revertCallbacks.push(controller.revert);
+    });
+    if (!isGlobalObserverPaused()) {
+      mutateRevert.current = () => {
+        revertCallbacks.reverse().forEach((c) => c());
+      };
+    }
+  };
 
   useEffect(() => {
-
     runMutations(variation?.domMutations);
   }, [variation]);
 
   const hasTextInChildren = (element: Element) => {
-        for (let child of element.children) {
-            // Trim the child element's text content
-            let isValid = !!child?.textContent?.trim();
-            // make carve out for the case where the child is a span or a or b or i or u
-           if(["span", "b", "i", "u", "a"].includes(element.tagName.toLowerCase())) isValid = true;
+    for (let child of element.children) {
+      // Trim the child element's text content
+      let isValid = !!child?.textContent?.trim();
+      // make carve out for the case where the child is a span or a or b or i or u
+      if (["span", "b", "i", "u", "a"].includes(element.tagName.toLowerCase()))
+        isValid = true;
 
-            if (!isValid || hasTextInChildren(child)) {
-                return true;
-            }
-        return false;
+      if (!isValid || hasTextInChildren(child)) {
+        return true;
+      }
+      return false;
     }
-  }
+  };
   const clearInlineEditAttributes = () => {
-    const inlineEditElements = document.querySelectorAll(`[canInlineEdit], [contenteditable]`);
+    const inlineEditElements = document.querySelectorAll(
+      `[canInlineEdit], [contenteditable]`,
+    );
     inlineEditElements.forEach((element) => {
       element.removeAttribute("canInlineEdit");
       element.removeAttribute("contenteditable");
     });
-    
-  }
+  };
 
   const resetAndStopInlineEditing = () => {
     resumeGlobalObserver();
-    if(variation?.domMutations.length === 0 && elementUnderEdit){
+    if (variation?.domMutations.length === 0 && elementUnderEdit) {
       elementUnderEdit.innerHTML = elementUnderEditHTML;
     }
 
     runMutations(variation?.domMutations);
-    
+
     if (!elementUnderEdit) return;
     elementUnderEdit.removeAttribute("contenteditable");
     elementUnderEdit.removeEventListener("keydown", setInnerHTMLOnInlineEdit);
-    if(!isInlineEditing){ 
+    if (!isInlineEditing) {
       clearInlineEditAttributes();
       setElementUnderEdit(null);
     }
     setIsInlineEditing(false);
-  }
+  };
 
   const stopInlineEditing = () => {
     if (!elementUnderEdit) return;
     clearInlineEditAttributes();
     const html = elementUnderEdit.innerHTML;
-    if(html !== elementUnderEditHTML && isInlineEditing){
+    if (html !== elementUnderEditHTML && isInlineEditing) {
       clearInlineEditAttributes();
       setInnerHTML(html);
     }
     elementUnderEdit.setAttribute("canInlineEdit", "true");
     resumeGlobalObserver();
-    elementUnderEdit.removeEventListener("keydown", ()=>{});
+    elementUnderEdit.removeEventListener("keydown", () => {});
     // we need to reset if it is not inline editing
-    if(!isInlineEditing){
+    if (!isInlineEditing) {
       setElementUnderEdit(null);
-    } 
+    }
     setIsInlineEditing(false);
-}
+  };
 
-const setInnerHTMLOnInlineEdit = (event: KeyboardEvent) => {
-
+  const setInnerHTMLOnInlineEdit = (event: KeyboardEvent) => {
     if (!elementUnderEdit) return;
-   if (event.key === "Enter") {
+    if (event.key === "Enter") {
       event.preventDefault();
       stopInlineEditing();
       return;
@@ -394,46 +399,49 @@ const setInnerHTMLOnInlineEdit = (event: KeyboardEvent) => {
       resetAndStopInlineEditing();
       return;
     }
-  }
+  };
   // checking to see if element can be inline edited
   // make a allow list of elements that can be inline edited
   // allow anything that is span or b or i or u or a
-  const canInlineEditElement = (element: Element) =>{
+  const canInlineEditElement = (element: Element) => {
     let isValid = !!element?.textContent?.trim();
     // if the element is empty and has no children, we can't inline edit it
-    if(element?.textContent?.trim() === "") isValid = true;    
+    if (element?.textContent?.trim() === "") isValid = true;
     return isValid && !hasTextInChildren(element);
-  }
-
+  };
 
   // event handlers
   useEffect(() => {
     if (!isEnabled) return;
-  const setInlineEditOnElement = (element: HTMLElement| null) => {
-    if(!element) return;
-    const canInlineEdit =  canInlineEditElement(element);
+    const setInlineEditOnElement = (element: HTMLElement | null) => {
+      if (!element) return;
+      const canInlineEdit = canInlineEditElement(element);
 
-    if (canInlineEdit) {
-      setIsInlineEditing(true);
-      document.removeEventListener("click", clickHandler, true);
-      document.removeEventListener("pointermove", onPointerMove, true);
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      pauseGlobalObserver();
-      element.setAttribute("contenteditable", "true");
-      element.focus();
-      const range = document.createRange();
-      const sel = window.getSelection();
-      range.selectNodeContents(element);
-      range.collapse(false);
-      sel?.removeAllRanges();
-      sel?.addRange(range);
-      elementUnderEdit?.addEventListener("keydown", setInnerHTMLOnInlineEdit, false);
-    } else {
-      setIsInlineEditing(false);
-    }
-  }
+      if (canInlineEdit) {
+        setIsInlineEditing(true);
+        document.removeEventListener("click", clickHandler, true);
+        document.removeEventListener("pointermove", onPointerMove, true);
+        document.removeEventListener("pointerdown", onPointerDown, true);
+        pauseGlobalObserver();
+        element.setAttribute("contenteditable", "true");
+        element.focus();
+        const range = document.createRange();
+        const sel = window.getSelection();
+        range.selectNodeContents(element);
+        range.collapse(false);
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+        elementUnderEdit?.addEventListener(
+          "keydown",
+          setInnerHTMLOnInlineEdit,
+          false,
+        );
+      } else {
+        setIsInlineEditing(false);
+      }
+    };
     const onPointerMove = throttle((event: MouseEvent) => {
-      if(elementUnderEdit) return;
+      if (elementUnderEdit) return;
       const { clientX: x, clientY: y } = event;
       const domNode = document.elementFromPoint(x, y);
       // return early if we are over the visual editor itself (e.g. frame)
@@ -451,51 +459,49 @@ const setInnerHTMLOnInlineEdit = (event: KeyboardEvent) => {
       setHighlightedElement(domNode as HTMLElement);
     }, 50);
 
-  const onPointerDown = (event: MouseEvent) => {
-    const element = event.target as HTMLElement;
-    if(elementUnderEdit) return;
-    if(elementUnderEdit === element) return;
-
-    // don't intercept cilcks on the visual editor itself
-    if (element.id === CONTAINER_ID) return;
-
-    event.preventDefault();
-    event.stopPropagation();
-  };
-  const setCursorForInlineEditing = (element: HTMLElement) => {
-    if(!element) return;
-    const canInlineEdit =  canInlineEditElement(element);
-    if (canInlineEdit) {
-      element.setAttribute("canInlineEdit", "true");
-    }
-  }
-
-
-
-    const clickHandler = (event: MouseEvent) => {
-      if (event.detail === 1) {
+    const onPointerDown = (event: MouseEvent) => {
       const element = event.target as HTMLElement;
-      if(isInlineEditing) return;
+      if (elementUnderEdit) return;
+      if (elementUnderEdit === element) return;
+
       // don't intercept cilcks on the visual editor itself
       if (element.id === CONTAINER_ID) return;
 
-      //need to set inline editing true before setting element under edit if it is not inline editing we revert the changes
-      if(!elementUnderEdit){
-       setElementUnderEdit(element);
-      }
-      // we want to set the element inline edit on the second click
-      setCursorForInlineEditing(element);
-      // we know that if you click anywhere else you want to stop inline editing
-      if(elementUnderEdit){
-       setInlineEditOnElement(elementUnderEdit);
-      }
       event.preventDefault();
       event.stopPropagation();
-    }
-  }; 
-        document.addEventListener("click", clickHandler, true);
-        document.addEventListener("pointermove", onPointerMove, true);
-        document.addEventListener("pointerdown", onPointerDown, true);
+    };
+    const setCursorForInlineEditing = (element: HTMLElement) => {
+      if (!element) return;
+      const canInlineEdit = canInlineEditElement(element);
+      if (canInlineEdit) {
+        element.setAttribute("canInlineEdit", "true");
+      }
+    };
+
+    const clickHandler = (event: MouseEvent) => {
+      if (event.detail === 1) {
+        const element = event.target as HTMLElement;
+        if (isInlineEditing) return;
+        // don't intercept cilcks on the visual editor itself
+        if (element.id === CONTAINER_ID) return;
+
+        //need to set inline editing true before setting element under edit if it is not inline editing we revert the changes
+        if (!elementUnderEdit) {
+          setElementUnderEdit(element);
+        }
+        // we want to set the element inline edit on the second click
+        setCursorForInlineEditing(element);
+        // we know that if you click anywhere else you want to stop inline editing
+        if (elementUnderEdit) {
+          setInlineEditOnElement(elementUnderEdit);
+        }
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    };
+    document.addEventListener("click", clickHandler, true);
+    document.addEventListener("pointermove", onPointerMove, true);
+    document.addEventListener("pointerdown", onPointerDown, true);
     return () => {
       clearHoverAttribute();
       setHighlightedElement(null);
@@ -504,7 +510,6 @@ const setInnerHTMLOnInlineEdit = (event: KeyboardEvent) => {
       document.removeEventListener("pointerdown", onPointerDown, true);
     };
   }, [isEnabled, elementUnderEdit, isInlineEditing]);
-
 
   return {
     elementUnderEdit,

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -122,7 +122,7 @@ const useEditMode: UseEditModeHook = ({
     );
     const text = parsed.body.textContent || "";
     return text.trim();
-  }, [currentElement, variation]);
+  }, [elementUnderEdit, variation]);
   
 
   const addDomMutations = useCallback(
@@ -172,7 +172,6 @@ const useEditMode: UseEditModeHook = ({
     (html: string) => {
       if(elementUnderEdit)
         if(variation?.domMutations.length === 0){
-          console.log("setting innerHTML", elementUnderEditCopy);
          elementUnderEdit.innerHTML = elementUnderEditCopy;
         }
       addDomMutations([

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -442,8 +442,13 @@ const useEditMode: UseEditModeHook = ({
     };
     const onPointerMove = throttle((event: MouseEvent) => {
       if (elementUnderEdit) return;
+ 
       const { clientX: x, clientY: y } = event;
-      const domNode = document.elementFromPoint(x, y);
+      let domNode = document.elementFromPoint(x, y);
+      const tagType = domNode?.tagName.toLowerCase();
+      if (tagType && ["b","i", "u"].includes(tagType)) {
+        domNode = domNode?.parentElement || null;
+      }
       // return early if we are over the visual editor itself (e.g. frame)
       if (domNode?.id === CONTAINER_ID) {
         clearHoverAttribute();
@@ -480,7 +485,12 @@ const useEditMode: UseEditModeHook = ({
 
     const clickHandler = (event: MouseEvent) => {
       if (event.detail === 1) {
-        const element = event.target as HTMLElement;
+        let element = event.target as HTMLElement;
+        const tagType = element?.tagName.toLowerCase();
+          if (tagType && ["b","i", "u"].includes(tagType)) {
+            element = element?.parentElement as HTMLElement;
+          }
+        if(!element) return;
         if (isInlineEditing) return;
         // don't intercept cilcks on the visual editor itself
         if (element.id === CONTAINER_ID) return;

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -18,15 +18,6 @@ const clearHoverAttribute = () => {
   });
 };
 
-function getOS() {
-  const userAgent = navigator.userAgent;
-  if (userAgent.indexOf("Win") !== -1) return "Windows";
-  if (userAgent.indexOf("Mac") !== -1) return "Mac";
-  if (userAgent.indexOf("Linux") !== -1) return "Linux";
-  if (userAgent.indexOf("X11") !== -1) return "Unix";
-  return "Unknown";
-}
-
 type UseEditModeHook = (args: {
   isEnabled: boolean;
   updateVariation: (updates: Partial<VisualEditorVariation>) => void;
@@ -169,7 +160,8 @@ const useEditMode: UseEditModeHook = ({
     (html: string) => {
       if(elementUnderEdit)
         if(variation?.domMutations.length === 0){
-         elementUnderEdit.innerHTML = elementUnderEditCopy;
+
+         elementUnderEdit.innerText = elementUnderEditCopy;
         }
       addDomMutations([
         {

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -14,7 +14,7 @@ import { VisualEditorVariation } from "../../../../devtools";
 export const hoverAttributeName = "gb-edit-mode-hover";
 
 // HTML attriibute names to ignore when editing
-export const IGNORED_ATTRS = ["class", hoverAttributeName];
+export const IGNORED_ATTRS = ["class", hoverAttributeName, "contenteditable", "caninlineedit"];
 
 const clearHoverAttribute = () => {
   const hoveredElements = document.querySelectorAll(`[${hoverAttributeName}]`);
@@ -344,10 +344,10 @@ const useEditMode: UseEditModeHook = ({
   };
   const clearInlineEditAttributes = () => {
     const inlineEditElements = document.querySelectorAll(
-      `[canInlineEdit], [contenteditable]`,
+      `[caninlineedit], [contenteditable]`,
     );
     inlineEditElements.forEach((element) => {
-      element.removeAttribute("canInlineEdit");
+      element.removeAttribute("caninlineedit");
       element.removeAttribute("contenteditable");
     });
   };
@@ -378,7 +378,7 @@ const useEditMode: UseEditModeHook = ({
       clearInlineEditAttributes();
       setInnerHTML(html);
     }
-    elementUnderEdit.setAttribute("canInlineEdit", "true");
+    elementUnderEdit.setAttribute("caninlineedit", "true");
     resumeGlobalObserver();
     elementUnderEdit.removeEventListener("keydown", () => {});
     // we need to reset if it is not inline editing
@@ -479,7 +479,7 @@ const useEditMode: UseEditModeHook = ({
       if (!element) return;
       const canInlineEdit = canInlineEditElement(element);
       if (canInlineEdit) {
-        element.setAttribute("canInlineEdit", "true");
+        element.setAttribute("caninlineedit", "true");
       }
     };
 

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -391,6 +391,7 @@ const setInnerHTMLOnInlineEdit = (event: KeyboardEvent) => {
   const setInlineEditOnElement = (element: HTMLElement| null) => {
     if(!element) return;
     const canInlineEdit =  canInlineEditElement(element);
+
     if (canInlineEdit) {
       setIsInlineEditing(true);
       document.removeEventListener("click", clickHandler, true);
@@ -411,7 +412,6 @@ const setInnerHTMLOnInlineEdit = (event: KeyboardEvent) => {
     }
   }
     const onPointerMove = throttle((event: MouseEvent) => {
-      console.log("pointer move");
       const { clientX: x, clientY: y } = event;
       const domNode = document.elementFromPoint(x, y);
 
@@ -443,8 +443,6 @@ const setInnerHTMLOnInlineEdit = (event: KeyboardEvent) => {
 
     event.preventDefault();
     event.stopPropagation();
-    setIsInlineEditing(true);
-    setElementUnderEdit(element);
   };
 
 
@@ -456,23 +454,22 @@ const setInnerHTMLOnInlineEdit = (event: KeyboardEvent) => {
       });
       // don't intercept cilcks on the visual editor itself
       if (element.id === CONTAINER_ID) return;
+
       //need to set inline editing true before setting element under edit if it is not inline editing we revert the changes
-      setIsInlineEditing(true);
+      const isCurrentElementUnderEdit = elementUnderEdit === element;
       setElementUnderEdit(element);
-      setInlineEditOnElement(element);
+      // we want to set the element inline edit on the second click
+      if(isCurrentElementUnderEdit){
+       setInlineEditOnElement(element);
+      }
       event.preventDefault();
       event.stopPropagation();
     }
   }; 
-      console.log("tesing");
-      // if(!isInlineEditing){
-        console.log("adding event listeners");
         document.addEventListener("click", clickHandler, true);
         document.addEventListener("pointermove", onPointerMove, true);
         document.addEventListener("pointerdown", onPointerDown, true);
-      // }
     return () => {
-      console.log("removing event listeners");
       clearHoverAttribute();
       setHighlightedElement(null);
       document.removeEventListener("click", clickHandler, true);

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -115,6 +115,7 @@ const useEditMode: UseEditModeHook = ({
 
   const addDomMutations = useCallback(
     (domMutations: DeclarativeMutation[]) => {
+      console.log("addDomMutations", domMutations);
       if (!variation || !updateVariation) return;
       const newDomMutations =  [...variation.domMutations, ...domMutations];
       updateVariation({
@@ -355,10 +356,7 @@ const useEditMode: UseEditModeHook = ({
 const setInnerHTMLOnInlineEdit = (event: KeyboardEvent) => {
 
     if (!elementUnderEdit) return;
-    if (event.key === "Enter" && event.altKey) {
-      elementUnderEdit.innerHTML = elementUnderEdit.innerHTML + "<br>";
-      return;
-    } else if (event.key === "Enter") {
+   if (event.key === "Enter") {
       event.preventDefault();
       stopInlineEditing();
       return;

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -115,9 +115,9 @@ const useEditMode: UseEditModeHook = ({
 
   const addDomMutations = useCallback(
     (domMutations: DeclarativeMutation[]) => {
-      console.log("addDomMutations", domMutations);
       if (!variation || !updateVariation) return;
       const newDomMutations =  [...variation.domMutations, ...domMutations];
+      console.log("how many mutations");
       updateVariation({
         domMutations: newDomMutations,
       });
@@ -164,6 +164,7 @@ const useEditMode: UseEditModeHook = ({
 
          elementUnderEdit.innerText = elementUnderEditCopy;
         }
+        console.log("setting inner html");
       addDomMutations([
         {
           action: "set",

--- a/src/visual_editor/lib/hooks/useFloatingAnchor.ts
+++ b/src/visual_editor/lib/hooks/useFloatingAnchor.ts
@@ -8,13 +8,12 @@ export default function useFloatingAnchor(parentElement: Element | null) {
   const onChange = useCallback(
     throttle(() => {
       let selector = "";
-      if(parentElement)
-       selector =  getSelector(parentElement);
+      if (parentElement) selector = getSelector(parentElement);
       // get element by query selector
       const rect = document.querySelector(selector)?.getBoundingClientRect();
       setDomRect(rect ?? null);
     }, 1000 / 60),
-    [parentElement, setDomRect]
+    [parentElement, setDomRect],
   );
 
   useEffect(() => {

--- a/src/visual_editor/lib/hooks/useFloatingAnchor.ts
+++ b/src/visual_editor/lib/hooks/useFloatingAnchor.ts
@@ -1,12 +1,17 @@
 import { useCallback, useEffect, useState } from "react";
 import { throttle } from "lodash";
+import getSelector from "../getSelector";
 
 export default function useFloatingAnchor(parentElement: Element | null) {
   const [domRect, setDomRect] = useState<DOMRect | null>(null);
 
   const onChange = useCallback(
     throttle(() => {
-      const rect = parentElement?.getBoundingClientRect();
+      let selector = "";
+      if(parentElement)
+       selector =  getSelector(parentElement);
+      // get element by query selector
+      const rect = document.querySelector(selector)?.getBoundingClientRect();
       setDomRect(rect ?? null);
     }, 1000 / 60),
     [parentElement, setDomRect]

--- a/src/visual_editor/lib/hooks/useGhostElement.ts
+++ b/src/visual_editor/lib/hooks/useGhostElement.ts
@@ -16,7 +16,7 @@ const cloneElement = (element: HTMLElement) => {
     const styleProperty = computedStyles[i];
     clone.style.setProperty(
       styleProperty,
-      computedStyles.getPropertyValue(styleProperty)
+      computedStyles.getPropertyValue(styleProperty),
     );
   }
 
@@ -31,7 +31,7 @@ const useGhostElement: UseGhostElementHook = ({
 }) => {
   const [ghostElement, setGhostElement] = useState<HTMLElement | null>(null);
   const [offsetPos, setOffsetPos] = useState<{ x: number; y: number } | null>(
-    null
+    null,
   );
 
   const setElementPosition = useCallback(
@@ -48,7 +48,7 @@ const useGhostElement: UseGhostElementHook = ({
       element.style.top = `${y - offsetPos.y}px`;
       element.style.left = `${x - offsetPos.x}px`;
     },
-    [targetElement, offsetPos]
+    [targetElement, offsetPos],
   );
 
   // reset offsetPos when targetElement changes

--- a/src/visual_editor/lib/hooks/useGlobalCSS.ts
+++ b/src/visual_editor/lib/hooks/useGlobalCSS.ts
@@ -22,7 +22,7 @@ export default function useGlobalCSS({
     debounce((css: string) => {
       updateVariation({ css });
     }, 1500),
-    [updateVariation]
+    [updateVariation],
   );
 
   useEffect(() => {

--- a/src/visual_editor/lib/hooks/useQueryParams.ts
+++ b/src/visual_editor/lib/hooks/useQueryParams.ts
@@ -19,7 +19,7 @@ type UseQueryParamsHook = () => {
 // normalize param values into number type
 // default to 1 (first variation)
 const getVariationIndexFromParams = (
-  param: string | (string | null)[] | null
+  param: string | (string | null)[] | null,
 ): number => {
   if (Array.isArray(param)) {
     if (!param[0]) return 1;
@@ -44,21 +44,21 @@ const cleanUpParams = (params: qs.ParsedQuery) => () => {
         // deprecated but still in use by old versions of GB app
         [EXPERIMENT_URL_PARAMS_KEY]: undefined,
       },
-    })
+    }),
   );
 };
 
 const useQueryParams: UseQueryParamsHook = () => {
   const params = qs.parse(window.location.search);
   const [visualChangesetId] = useState(
-    (params[VISUAL_CHANGESET_ID_PARAMS_KEY] || "") as string
+    (params[VISUAL_CHANGESET_ID_PARAMS_KEY] || "") as string,
   );
   const [variationIndex] = useState(
-    getVariationIndexFromParams(params[VARIATION_INDEX_PARAMS_KEY])
+    getVariationIndexFromParams(params[VARIATION_INDEX_PARAMS_KEY]),
   );
   const [hasAiEnabled] = useState(
     decodeURIComponent((params[AI_ENABLED_PARAMS_KEY] || "") as string) ===
-      "true"
+      "true",
   );
   return {
     params,

--- a/src/visual_editor/lib/hooks/useSDKDiagnostics.ts
+++ b/src/visual_editor/lib/hooks/useSDKDiagnostics.ts
@@ -38,7 +38,7 @@ const useSDKDiagnostics: UseSDKDiagnosticsHook = ({ experiment }) => {
     setHasHashAttr(
       hasSDK
         ? !!sdkAttributes?.hasOwnProperty(experiment?.hashAttribute || "")
-        : false
+        : false,
     );
   }, [hasSDK, hashAttribute]);
 

--- a/src/visual_editor/lib/hooks/useVisualChangeset.ts
+++ b/src/visual_editor/lib/hooks/useVisualChangeset.ts
@@ -9,14 +9,13 @@ import {
   UpdateVisualChangesetRequestMessage,
 } from "../../../../devtools";
 import normalizeVariations from "../normalizeVariations";
-import { update } from "lodash";
 type UseVisualChangesetHook = (visualChangesetId: string) => {
   loading: boolean;
   experimentUrl: string | null;
   variations: VisualEditorVariation[];
   updateVariationAtIndex: (
     index: number,
-    updates: Partial<VisualEditorVariation>
+    updates: Partial<VisualEditorVariation>,
   ) => void;
   error: string | null;
   cspError: CSPError | null;
@@ -71,7 +70,7 @@ const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
 
       window.postMessage(updateVisualChangesetMessage, window.location.origin);
     },
-    [visualChangesetId]
+    [visualChangesetId],
   );
 
   const updateVariationAtIndex = useCallback(
@@ -86,7 +85,7 @@ const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
       updateVisualChangeset(newVariations);
       setVariations(newVariations);
     },
-    [variations, setVariations, updateVisualChangeset]
+    [variations, setVariations, updateVisualChangeset],
   );
 
   // generate normalized variations
@@ -110,7 +109,8 @@ const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
 
       switch (msg.type) {
         case "GB_RESPONSE_LOAD_VISUAL_CHANGESET":
-          if (msg.data.error && typeof msg.data.error === "string") setError(msg.data.error);
+          if (msg.data.error && typeof msg.data.error === "string")
+            setError(msg.data.error);
           else {
             setVisualChangeset(msg.data.visualChangeset);
             setExperiment(msg.data.experiment);
@@ -119,7 +119,8 @@ const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
           setLoading(false);
           break;
         case "GB_RESPONSE_UPDATE_VISUAL_CHANGESET":
-          if (msg.data.error && typeof msg.data.error === "string") setError(msg.data.error);
+          if (msg.data.error && typeof msg.data.error === "string")
+            setError(msg.data.error);
           setLoading(false);
           break;
         default:

--- a/src/visual_editor/lib/hooks/useVisualChangeset.ts
+++ b/src/visual_editor/lib/hooks/useVisualChangeset.ts
@@ -107,9 +107,11 @@ const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
 
     const messageHandler = (event: MessageEvent<Message>) => {
       const msg = event.data;
+
       switch (msg.type) {
         case "GB_RESPONSE_LOAD_VISUAL_CHANGESET":
-          if (msg.data.error) setError(msg.data.error);
+          if(msg?.data.error && typeof msg.data.error === "string")
+          if (msg.data.error && typeof msg.data.error === "string") setError(msg.data.error);
           else {
             setVisualChangeset(msg.data.visualChangeset);
             setExperiment(msg.data.experiment);
@@ -118,7 +120,8 @@ const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
           setLoading(false);
           break;
         case "GB_RESPONSE_UPDATE_VISUAL_CHANGESET":
-          if (msg.data.error) setError(msg.data.error);
+          if(msg?.data.error && typeof msg.data.error === "string")
+          if (msg.data.error && typeof msg.data.error === "string") setError(msg.data.error);
           setLoading(false);
           break;
         default:

--- a/src/visual_editor/lib/hooks/useVisualChangeset.ts
+++ b/src/visual_editor/lib/hooks/useVisualChangeset.ts
@@ -9,6 +9,7 @@ import {
   UpdateVisualChangesetRequestMessage,
 } from "../../../../devtools";
 import normalizeVariations from "../normalizeVariations";
+import { update } from "lodash";
 type UseVisualChangesetHook = (visualChangesetId: string) => {
   loading: boolean;
   experimentUrl: string | null;
@@ -59,7 +60,6 @@ const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
           description: v.description,
         })),
       };
-
       const updateVisualChangesetMessage: UpdateVisualChangesetRequestMessage =
         {
           type: "GB_REQUEST_UPDATE_VISUAL_CHANGESET",
@@ -110,7 +110,6 @@ const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
 
       switch (msg.type) {
         case "GB_RESPONSE_LOAD_VISUAL_CHANGESET":
-          if(msg?.data.error && typeof msg.data.error === "string")
           if (msg.data.error && typeof msg.data.error === "string") setError(msg.data.error);
           else {
             setVisualChangeset(msg.data.visualChangeset);
@@ -120,7 +119,6 @@ const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
           setLoading(false);
           break;
         case "GB_RESPONSE_UPDATE_VISUAL_CHANGESET":
-          if(msg?.data.error && typeof msg.data.error === "string")
           if (msg.data.error && typeof msg.data.error === "string") setError(msg.data.error);
           setLoading(false);
           break;

--- a/src/visual_editor/lib/moveElement.ts
+++ b/src/visual_editor/lib/moveElement.ts
@@ -3,7 +3,7 @@ const dragTargetEdgeAttributeName = "gb-edit-mode-drag-target-edge";
 
 const clearDragTargetEdges = () => {
   const targetEdges = document.querySelectorAll(
-    `[${dragTargetEdgeAttributeName}]`
+    `[${dragTargetEdgeAttributeName}]`,
   );
   targetEdges.forEach((targetEdge) => {
     targetEdge.remove();
@@ -12,7 +12,7 @@ const clearDragTargetEdges = () => {
 
 const clearDragTargetAttribute = () => {
   const targetElements = document.querySelectorAll(
-    `[${dragTargetAttributeName}]`
+    `[${dragTargetAttributeName}]`,
   );
   targetElements.forEach((targetElement) => {
     targetElement.removeAttribute(dragTargetAttributeName);

--- a/src/visual_editor/lib/normalizeVariations.ts
+++ b/src/visual_editor/lib/normalizeVariations.ts
@@ -20,7 +20,7 @@ const normalizeVariations = ({
       acc[variation] = visualChange;
       return acc;
     },
-    {}
+    {},
   );
 
   return variations.map((variation: APIExperimentVariation) => {

--- a/src/visual_editor/targetPage.css
+++ b/src/visual_editor/targetPage.css
@@ -19,3 +19,6 @@
   position: fixed;
   @apply gb-z-max;
 }
+[contenteditable]:focus {
+  outline: 0px solid transparent;
+}

--- a/src/visual_editor/targetPage.css
+++ b/src/visual_editor/targetPage.css
@@ -2,6 +2,10 @@
   display: block !important;
 }
 
+[gb-edit-mode-hover][contenteditable="true"] {
+  cursor: text !important;
+}
+
 [gb-edit-mode-hover] {
   cursor: crosshair;
 }

--- a/src/visual_editor/targetPage.css
+++ b/src/visual_editor/targetPage.css
@@ -2,7 +2,7 @@
   display: block !important;
 }
 
-[gb-edit-mode-hover][contenteditable="true"] {
+[canInlineEdit] {
   cursor: text !important;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,6 +2777,11 @@ dom-mutator@^0.6.0:
   resolved "https://registry.yarnpkg.com/dom-mutator/-/dom-mutator-0.6.0.tgz#079d7a4b3e8981a562cd777548b99baab51d65c5"
   integrity sha512-iCt9o0aYfXMUkz/43ZOAUFQYotjGB+GNbYJiJdz4TgXkyToXbbRy5S6FbTp72lRBtfpUMwEc1KmpFEU4CZeoNg==
 
+dom-mutator@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dom-mutator/-/dom-mutator-0.7.0.tgz#3d2a46bca1e93757bc643e9bede8360a41ced83d"
+  integrity sha512-WgpTCBkYaib9lanHAkBuHirP1q5yQi1RDzlNsqvIDCgDkNyEhvFvsnmaz3ZztoRhtz6/ZwBrGs/VohlSstCt5g==
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"


### PR DESCRIPTION
## Description
Added the ability to add inline editing on elements
## test
you will need to set up the dom mutator with `gl/inline-editor` and link that to this repo
- to test this you will need to edit an element that only has children with text in them.
- the first click is to focus the element and the second click is to start inline editing
- enter  will save the changes you made
- clicking away with save the changes
- escape will discard the changes

