### PR TITLE
Add plumbing to pull saved overrides on pageload

### DIFF
--- a/devtools.d.ts
+++ b/devtools.d.ts
@@ -1,7 +1,8 @@
 import type {
   Experiment,
   FeatureDefinition,
-  ExperimentOverride, StickyAssignmentsDocument,
+  ExperimentOverride,
+  StickyAssignmentsDocument,
 } from "@growthbook/growthbook";
 import {
   FetchVisualChangesetPayload,
@@ -162,6 +163,10 @@ type UpdateTabState = {
   };
 };
 
+type PullOverrides = {
+  type: "GB_REQUEST_OVERRIDES";
+};
+
 // Messages sent to content script
 export type Message =
   | RequestRefreshMessage
@@ -176,7 +181,8 @@ export type Message =
   | UpdateVisualChangesetResponseMessage
   | TransformCopyRequestMessage
   | TransformCopyResponseMessage
-  | UpdateTabState;
+  | UpdateTabState
+  | PullOverrides;
 
 export type BGLoadVisualChangsetMessage = {
   type: "BG_LOAD_VISUAL_CHANGESET";
@@ -217,7 +223,7 @@ type SDKHealthCheckResult = {
   hasTrackingCallback?: boolean;
   trackingCallbackParams?: string[];
   hasDecryptionKey?: boolean;
-  payloadDecrypted?:boolean;
+  payloadDecrypted?: boolean;
   usingLogEvent?: boolean;
   usingOnFeatureUsage?: boolean;
   isRemoteEval?: boolean;

--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -66,6 +66,7 @@ function onGrowthBookLoad(cb: (gb: GrowthBook) => void) {
 function init() {
   setupListeners();
   pushAppUpdates();
+  pullOverrides();
   document.addEventListener("visibilitychange", () => {
     if (document.visibilityState === "visible") {
       pushAppUpdates();
@@ -188,6 +189,16 @@ function updateTabState(property: string, value: unknown, append = false) {
         value,
       },
       append,
+    },
+    window.location.origin,
+  );
+}
+
+// Prompt the content script to send the existing overrides on pageload
+function pullOverrides() {
+  window.postMessage(
+    {
+      type: "GB_REQUEST_OVERRIDES",
     },
     window.location.origin,
   );

--- a/src/content_script/index.ts
+++ b/src/content_script/index.ts
@@ -6,13 +6,12 @@ import {
   visualEditorTransformCopyRequest,
   visualEditorUpdateChangesetRequest,
 } from "@/content_script/pageMessageHandlers";
-import { at } from "lodash";
 
 const forceLoadVisualEditor = false;
 export const SESSION_STORAGE_TAB_STATE_KEY = "growthbook-devtools-tab-state";
 
 // Special state variables will push their updates to the embed script / SDK when changed:
-const propertiesWithCustomMessage = {
+const propertiesWithCustomMessage: Record<string, string> = {
   attributes: "GB_UPDATE_ATTRIBUTES", // setAttributes
   forcedFeatures: "GB_UPDATE_FEATURES", // setForcedFeatures
   forcedVariations: "GB_UPDATE_EXPERIMENTS", // setForcedVariations
@@ -85,6 +84,18 @@ function setState(property: string, value: any, skipPostMessage?: boolean) {
   }
 }
 
+function pushAllOverrides() {
+  Object.keys(propertiesWithCustomMessage).forEach((stateProp) => {
+    const { state: stateValue, success } = getState(stateProp);
+    if (success) {
+      window.postMessage(
+        { type: propertiesWithCustomMessage[stateProp], data: stateValue },
+        window.location.origin,
+      );
+    }
+  });
+}
+
 // Listen for messages from the App
 chrome.runtime.onMessage.addListener((message, _, sendResponse) => {
   try {
@@ -137,6 +148,9 @@ window.addEventListener(
       case "GB_SDK_UPDATED":
         // passthrough to background worker:nvm
         chrome.runtime.sendMessage(data);
+        break;
+      case "GB_REQUEST_OVERRIDES":
+        pushAllOverrides();
         break;
       default:
         break;


### PR DESCRIPTION
Adds a helper to the embed script for firing a message to the content script during `init()`. That message prompts the content script to send down all the overrides saved in tabState