### PR TITLE
Prevent spamming requests if the clientKey is not set

### DIFF
--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -406,6 +406,30 @@ async function SDKHealthCheck(gb?: GrowthBook): Promise<SDKHealthCheckResult> {
   const usingStickyBucketing = gbContext?.stickyBucketService !== undefined;
   const stickyBucketAssignmentDocs = gbContext?.stickyBucketAssignmentDocs;
 
+  if (!clientKey) {
+    return {
+      canConnect: false,
+      hasClientKey: false,
+      sdkFound: true,
+      devModeEnabled,
+      version: gb?.version,
+      hasWindowConfig: !!window?.growthbook_config,
+      hasPayload,
+      payload,
+      hasDecryptionKey,
+      payloadDecrypted,
+      hasTrackingCallback,
+      trackingCallbackParams,
+      usingLogEvent,
+      usingOnFeatureUsage,
+      isRemoteEval,
+      usingStickyBucketing,
+      stickyBucketAssignmentDocs,
+      apiHost,
+      errorMessage: "No Client Key was found",
+    };
+  }
+
   const apiRequestHeaders = gbContext?.apiRequestHeaders;
   let res;
   try {


### PR DESCRIPTION
Hey! When using the new version of the SDK, I noticed continuous failing requests to `/api/features` when the `clientKey` is not set:
<img width="946" alt="image" src="https://github.com/user-attachments/assets/423ae40a-4567-4053-b38b-7918a3e413b7" />

This PR adds a check to prevent making API calls if the `clientKey`. I am returning most of the fields to show the information in the status panel:
<img width="697" alt="image" src="https://github.com/user-attachments/assets/83fc4fc8-8ba9-487d-b669-096070e5804b" />
