### PR TITLE
Use the CSS.escape method when selecting elements with experiment ids

### DIFF
--- a/src/app/components/ExperimentsTab.tsx
+++ b/src/app/components/ExperimentsTab.tsx
@@ -161,7 +161,9 @@ export default function ExperimentsTab() {
     if (selectedEid) {
       const container = document.querySelector("#pageBody");
       const el = document.querySelector(
-        `#experimentsTab_experimentList_${selectedEid}_${selectedChangeId}`,
+        CSS.escape(
+          `#experimentsTab_experimentList_${selectedEid}_${selectedChangeId}`,
+        ),
       );
       const y =
         (el?.getBoundingClientRect()?.top || 0) + (container?.scrollTop || 0);

--- a/src/app/components/FeaturesTab.tsx
+++ b/src/app/components/FeaturesTab.tsx
@@ -111,7 +111,7 @@ export default function FeaturesTab() {
     if (selectedFid) {
       const container = document.querySelector("#pageBody");
       const el = document.querySelector(
-        `#featuresTab_featureList_${selectedFid}`,
+        CSS.escape(`#featuresTab_featureList_${selectedFid}`),
       );
       const y =
         (el?.getBoundingClientRect()?.top || 0) + (container?.scrollTop || 0);


### PR DESCRIPTION
[Issue 86](https://github.com/growthbook/devtools/issues/86) is caused by the CSS selector. This PR [escapes](https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape_static) selectors with the experiment id.

Build with the change:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/cf66229c-74ad-4890-ba91-00900bab11be" />
