### PR TITLE
Fix default value of null infered as string not json

### DIFF
--- a/src/app/components/FeaturesTab.tsx
+++ b/src/app/components/FeaturesTab.tsx
@@ -341,6 +341,8 @@ export function getFeatureDetails({
   let valueType: ValueType;
   if (meta?.valueType) {
     valueType = meta?.valueType;
+  } else if (feature?.defaultValue === null) {
+    valueType = "json";
   } else {
     valueType =
       (typeof (feature?.defaultValue ?? "string") as ValueType) || "object";


### PR DESCRIPTION
When this value type inference is run on a feature with a `defaultValue` of `null`, it results in `string` rather than `object`.
```
valueType =
      (typeof (feature?.defaultValue ?? "string") as ValueType) || "object";
```
Added a separate `else if` clause to support this default value