### PR TITLE
chore: add back build:* script commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "clean": "rimraf dist",
     "test": "npx jest",
     "style": "prettier --write \"src/**/*.{ts,tsx}\"",
+    "build:chrome": "yarn clean && yarn build && cp public/manifest.chrome.json dist/manifest.json && cd dist && rm -f manifest.*.json",
+    "build:firefox": "yarn clean && yarn build && cp public/manifest.firefox.json dist/manifest.json && cd dist && rm -f manifest.*.json",
     "package:chrome": "yarn clean && yarn build && cp public/manifest.chrome.json dist/manifest.json && cd dist && rm -f manifest.*.json && zip -r build.chrome.zip . && mv build.chrome.zip ../",
     "package:firefox": "yarn clean && yarn build && cp public/manifest.firefox.json dist/manifest.json && cd dist && rm -f manifest.*.json && zip -r build.firefox.zip . && mv build.firefox.zip ../"
   },


### PR DESCRIPTION
### Features and Changes

Hey there, today I came cross #91 and tried to fix it by myself so I followed the `README.md`.
> Run yarn build:chrome or yarn build:firefox to create a new build

It doesn't work, it seems the documentation is outdated.
<img width="633" alt="image" src="https://github.com/user-attachments/assets/796d15b9-051f-424b-b59e-52c3ef01bb91" />

### Dependencies

None

### Testing

Just run the command in terminal

### Screenshots
```bash
yarn build:chrome
yarn run v1.22.22
$ yarn clean && yarn build && cp public/manifest.chrome.json dist/manifest.json && cd dist && rm -f manifest.*.json
$ rimraf dist
$ webpack --config webpack/webpack.prod.js
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
assets by path ../ 841 KiB
  assets by path ../*.png 10.2 KiB 3 assets
  assets by path ../*.html 898 bytes 3 assets
  assets by path ../*.json 1.97 KiB 2 assets
  asset ../css/popup.css 828 KiB [emitted] [big] (name: popup)
assets by path *.js 2.27 MiB
  assets by status 2.1 MiB [big]
    asset popup.js 1.54 MiB [emitted] [minimized] [big] (name: popup) 1 related asset
    asset visual_editor.js 573 KiB [emitted] [minimized] [big] (name: visual_editor) 1 related asset
  + 4 assets
asset logo128.png 2.97 KiB [emitted] [from: public/logo128.png] (auxiliary name: visual_editor)
orphan modules 20 MiB (javascript) 937 bytes (runtime) [orphan] 766 modules
runtime modules 6.48 KiB 20 modules
cacheable modules 20.3 MiB (javascript) 828 KiB (css/mini-extract) 2.97 KiB (asset) 341 modules

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  ../css/popup.css (828 KiB)
  popup.js (1.54 MiB)
  visual_editor.js (573 KiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  popup (2.35 MiB)
      ../css/popup.css
      popup.js
  visual_editor (573 KiB)
      visual_editor.js


WARNING in webpack performance recommendations: 
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/

webpack 5.97.1 compiled with 3 warnings in 27452 ms
✨  Done in 30.07s.
```
Now I can it on Chrome ✅
![image](https://github.com/user-attachments/assets/4cde627c-3208-48f7-bc32-9bacf351d774)