### PR TITLE
Import/export state

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Some notes
 
 ## Changelog
 
+*1.1.0* (2025-03-11)
+- Share DevTools session by link
+- Import/export DevTools session by JSON blob
+- Preview draft features & experiments not in SDK payload
+- Bug fixes (occasional attributes tab crashes, mislabeled experiment overrides, theme flickering)
+
 *1.0.4* (2025-03-05)
 - Ability to clear individual attribute overrides
 - Bug fixes (legacy SDK support, prevent attribute caching, search)

--- a/devtools.d.ts
+++ b/devtools.d.ts
@@ -2,7 +2,7 @@ import type {
   Experiment,
   FeatureDefinition,
   ExperimentOverride,
-  StickyAssignmentsDocument,
+  StickyAssignmentsDocument, FeatureApiResponse,
 } from "@growthbook/growthbook";
 import {
   FetchVisualChangesetPayload,
@@ -167,6 +167,16 @@ type PullOverrides = {
   type: "GB_REQUEST_OVERRIDES";
 };
 
+type SetPayload = {
+  type: "SET_PAYLOAD";
+  data: FeatureApiResponse;
+};
+
+type PatchPayload = {
+  type: "PATCH_PAYLOAD";
+  data: FeatureApiResponse;
+};
+
 type CopyToClipboard = {
   type: "COPY_TO_CLIPBOARD";
   value: string;
@@ -188,6 +198,8 @@ export type Message =
   | TransformCopyResponseMessage
   | UpdateTabState
   | PullOverrides
+  | SetPayload
+  | PatchPayload
   | CopyToClipboard;
 
 export type BGLoadVisualChangsetMessage = {

--- a/devtools.d.ts
+++ b/devtools.d.ts
@@ -167,6 +167,11 @@ type PullOverrides = {
   type: "GB_REQUEST_OVERRIDES";
 };
 
+type CopyToClipboard = {
+  type: "COPY_TO_CLIPBOARD";
+  value: string;
+};
+
 // Messages sent to content script
 export type Message =
   | RequestRefreshMessage
@@ -182,7 +187,8 @@ export type Message =
   | TransformCopyRequestMessage
   | TransformCopyResponseMessage
   | UpdateTabState
-  | PullOverrides;
+  | PullOverrides
+  | CopyToClipboard;
 
 export type BGLoadVisualChangsetMessage = {
   type: "BG_LOAD_VISUAL_CHANGESET";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gb-devtools",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "webpack --config webpack/webpack.dev.js --watch",

--- a/public/devtools_panel.html
+++ b/public/devtools_panel.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="css/popup.css">
   </head>
   <body style="overflow-y: hidden; min-height: 100vh;">
-    <div id="root" data-is-devtools="1"></div>
+    <div id="root" data-is-devtools-panel="1"></div>
     <script src="js/popup.js"></script>
   </body>
 </html>

--- a/public/devtools_panel.html
+++ b/public/devtools_panel.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="css/popup.css">
   </head>
   <body style="overflow-y: hidden; min-height: 100vh;">
-    <div id="root"></div>
+    <div id="root" data-is-devtools="1"></div>
     <script src="js/popup.js"></script>
   </body>
 </html>

--- a/public/manifest.chrome.json
+++ b/public/manifest.chrome.json
@@ -30,7 +30,7 @@
     "service_worker": "js/background.js"
   },
 
-  "permissions": ["storage"],
+  "permissions": ["storage", "clipboardWrite"],
 
   "host_permissions": ["<all_urls>"],
 

--- a/public/manifest.chrome.json
+++ b/public/manifest.chrome.json
@@ -3,7 +3,7 @@
 
   "name": "GrowthBook DevTools",
   "description": "GrowthBook DevTools helps you debug feature flags and experiments and design A/B tests visually — all from your browser.",
-  "version": "1.0.4",
+  "version": "1.1.0",
 
   "content_scripts": [
     {

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -3,7 +3,7 @@
 
   "name": "GrowthBook DevTools",
   "description": "GrowthBook DevTools helps you debug feature flags and experiments and design A/B tests visually — all from your browser.",
-  "version": "1.0.4",
+  "version": "1.1.0",
 
   "browser_specific_settings": {
     "gecko": {

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -37,7 +37,7 @@
     "scripts": ["js/background.js"]
   },
 
-  "permissions": ["storage"],
+  "permissions": ["storage", "clipboardWrite"],
 
   "host_permissions": ["<all_urls>"],
 

--- a/src/app/components/AppMenu.tsx
+++ b/src/app/components/AppMenu.tsx
@@ -1,14 +1,17 @@
-import {DropdownMenu, Flex, IconButton, Tooltip} from "@radix-ui/themes";
+import { DropdownMenu, Flex, IconButton, Tooltip } from "@radix-ui/themes";
 import {
   PiBellFill,
   PiCircleFill,
   PiCircleHalfBold,
-  PiDotsThreeVerticalBold, PiDownloadSimpleBold, PiGearSixFill, PiLinkBold,
+  PiDotsThreeVerticalBold,
+  PiDownloadSimpleBold,
+  PiGearSixFill,
+  PiLinkBold,
   PiMoonBold,
-  PiSunBold
+  PiSunBold,
 } from "react-icons/pi";
 import React from "react";
-import {Theme} from "@/app";
+import { Theme } from "@/app";
 
 export function AppMenu({
   apiKeyReady,
@@ -19,87 +22,94 @@ export function AppMenu({
   setShareOpen,
   setImportOpen,
 }: {
-  apiKeyReady: boolean,
-  apiKey: string,
-  theme: "system" | "light" | "dark",
+  apiKeyReady: boolean;
+  apiKey: string;
+  theme: "system" | "light" | "dark";
   setTheme: (t: Theme) => void;
   setSettingsOpen: (b: boolean) => void;
   setShareOpen: (b: boolean) => void;
   setImportOpen: (b: boolean) => void;
 }) {
-  return <DropdownMenu.Root>
-    <DropdownMenu.Trigger>
-      {apiKeyReady && !apiKey ? (
-        <div>
-          <Tooltip content="Enter an Access Token for improved functionality">
-            <IconButton className="relative" variant="outline" radius="small" size="1">
-              <PiCircleFill
-                size={11}
-                className="absolute text-red-600 bg-surface rounded-full border border-surface"
-                style={{right: -4, top: -4}}
-              />
-              <PiDotsThreeVerticalBold />
-            </IconButton>
-          </Tooltip>
-        </div>
-      ) : (
-        <IconButton variant="outline" radius="small" size="1">
-          <PiDotsThreeVerticalBold/>
-        </IconButton>
-      )}
-    </DropdownMenu.Trigger>
-    <DropdownMenu.Content variant="soft">
-      <DropdownMenu.Sub>
-        <DropdownMenu.SubTrigger>
-          {theme === "system" ? (
-            <PiCircleHalfBold/>
-          ) : theme === "dark" ? (
-            <PiMoonBold/>
-          ) : (
-            <PiSunBold/>
-          )}
-          Theme
-        </DropdownMenu.SubTrigger>
-        <DropdownMenu.SubContent>
-          <DropdownMenu.Item onSelect={() => setTheme("system")}>
-            <PiCircleHalfBold/>
-            System default
-          </DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={() => setTheme("light")}>
-            <PiSunBold/>
-            Light
-          </DropdownMenu.Item>
-          <DropdownMenu.Item onSelect={() => setTheme("dark")}>
-            <PiMoonBold/>
-            Dark
-          </DropdownMenu.Item>
-        </DropdownMenu.SubContent>
-      </DropdownMenu.Sub>
-      <DropdownMenu.Item onSelect={() => setShareOpen(true)}>
-        <PiLinkBold />
-        Share...
-      </DropdownMenu.Item>
-      <DropdownMenu.Item onSelect={() => setImportOpen(true)}>
-        <PiDownloadSimpleBold />
-        Import / Export
-      </DropdownMenu.Item>
-      <DropdownMenu.Separator />
-      <DropdownMenu.Item
-        className="flex justify-between items-center"
-        onSelect={() => setSettingsOpen(true)}
-      >
-        <Flex gap="2" align="center">
-          <PiGearSixFill />
-          Settings
-        </Flex>
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
         {apiKeyReady && !apiKey ? (
-          <Tooltip content="Enter an Access Token for improved functionality">
-            <div className="p-1 text-red-600">
-              <PiBellFill/>
-            </div>
-          </Tooltip>
-        ) : null}
-      </DropdownMenu.Item>
-    </DropdownMenu.Content>
-  </DropdownMenu.Root>;
+          <div>
+            <Tooltip content="Enter an Access Token for improved functionality">
+              <IconButton
+                className="relative"
+                variant="outline"
+                radius="small"
+                size="1"
+              >
+                <PiCircleFill
+                  size={11}
+                  className="absolute text-red-600 bg-surface rounded-full border border-surface"
+                  style={{ right: -4, top: -4 }}
+                />
+                <PiDotsThreeVerticalBold />
+              </IconButton>
+            </Tooltip>
+          </div>
+        ) : (
+          <IconButton variant="outline" radius="small" size="1">
+            <PiDotsThreeVerticalBold />
+          </IconButton>
+        )}
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content variant="soft">
+        <DropdownMenu.Sub>
+          <DropdownMenu.SubTrigger>
+            {theme === "system" ? (
+              <PiCircleHalfBold />
+            ) : theme === "dark" ? (
+              <PiMoonBold />
+            ) : (
+              <PiSunBold />
+            )}
+            Theme
+          </DropdownMenu.SubTrigger>
+          <DropdownMenu.SubContent>
+            <DropdownMenu.Item onSelect={() => setTheme("system")}>
+              <PiCircleHalfBold />
+              System default
+            </DropdownMenu.Item>
+            <DropdownMenu.Item onSelect={() => setTheme("light")}>
+              <PiSunBold />
+              Light
+            </DropdownMenu.Item>
+            <DropdownMenu.Item onSelect={() => setTheme("dark")}>
+              <PiMoonBold />
+              Dark
+            </DropdownMenu.Item>
+          </DropdownMenu.SubContent>
+        </DropdownMenu.Sub>
+        <DropdownMenu.Item onSelect={() => setShareOpen(true)}>
+          <PiLinkBold />
+          Share...
+        </DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => setImportOpen(true)}>
+          <PiDownloadSimpleBold />
+          Import / Export
+        </DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item
+          className="flex justify-between items-center"
+          onSelect={() => setSettingsOpen(true)}
+        >
+          <Flex gap="2" align="center">
+            <PiGearSixFill />
+            Settings
+          </Flex>
+          {apiKeyReady && !apiKey ? (
+            <Tooltip content="Enter an Access Token for improved functionality">
+              <div className="p-1 text-red-600">
+                <PiBellFill />
+              </div>
+            </Tooltip>
+          ) : null}
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  );
 }

--- a/src/app/components/AppMenu.tsx
+++ b/src/app/components/AppMenu.tsx
@@ -1,0 +1,103 @@
+import {DropdownMenu, Flex, IconButton, Tooltip} from "@radix-ui/themes";
+import {
+  PiBellFill,
+  PiCircleFill,
+  PiCircleHalfBold,
+  PiDotsThreeVerticalBold, PiDownloadSimpleBold, PiGearSixFill, PiLinkBold,
+  PiMoonBold,
+  PiSunBold
+} from "react-icons/pi";
+import React from "react";
+import {Theme} from "@/app";
+
+export function AppMenu({
+  apiKeyReady,
+  apiKey,
+  theme,
+  setTheme,
+  setSettingsOpen,
+  setShareOpen,
+}: {
+  apiKeyReady: boolean,
+  apiKey: string,
+  theme: "system" | "light" | "dark",
+  setTheme: (t: Theme) => void;
+  setSettingsOpen: (b: boolean) => void;
+  setShareOpen: (b: boolean) => void;
+}) {
+  return <DropdownMenu.Root>
+    <DropdownMenu.Trigger>
+      {apiKeyReady && !apiKey ? (
+        <div>
+          <Tooltip content="Enter an Access Token for improved functionality">
+            <IconButton className="relative" variant="outline" radius="small" size="1">
+              <PiCircleFill
+                size={11}
+                className="absolute text-red-600 bg-surface rounded-full border border-surface"
+                style={{right: -4, top: -4}}
+              />
+              <PiDotsThreeVerticalBold/>
+            </IconButton>
+          </Tooltip>
+        </div>
+      ) : (
+        <IconButton variant="outline" radius="small" size="1">
+          <PiDotsThreeVerticalBold/>
+        </IconButton>
+      )}
+    </DropdownMenu.Trigger>
+    <DropdownMenu.Content variant="soft">
+      <DropdownMenu.Sub>
+        <DropdownMenu.SubTrigger>
+          {theme === "system" ? (
+            <PiCircleHalfBold/>
+          ) : theme === "dark" ? (
+            <PiMoonBold/>
+          ) : (
+            <PiSunBold/>
+          )}
+          Theme
+        </DropdownMenu.SubTrigger>
+        <DropdownMenu.SubContent>
+          <DropdownMenu.Item onSelect={() => setTheme("system")}>
+            <PiCircleHalfBold/>
+            System default
+          </DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => setTheme("light")}>
+            <PiSunBold/>
+            Light
+          </DropdownMenu.Item>
+          <DropdownMenu.Item onSelect={() => setTheme("dark")}>
+            <PiMoonBold/>
+            Dark
+          </DropdownMenu.Item>
+        </DropdownMenu.SubContent>
+      </DropdownMenu.Sub>
+      <DropdownMenu.Item onSelect={() => setShareOpen(true)}>
+        <PiLinkBold />
+        Share...
+      </DropdownMenu.Item>
+      <DropdownMenu.Item>
+        <PiDownloadSimpleBold />
+        Import / Export
+      </DropdownMenu.Item>
+      <DropdownMenu.Separator />
+      <DropdownMenu.Item
+        className="flex justify-between items-center"
+        onSelect={() => setSettingsOpen(true)}
+      >
+        <Flex gap="2" align="center">
+          <PiGearSixFill />
+          Settings
+        </Flex>
+        {apiKeyReady && !apiKey ? (
+          <Tooltip content="Enter an Access Token for improved functionality">
+            <div className="p-1 text-red-600">
+              <PiBellFill/>
+            </div>
+          </Tooltip>
+        ) : null}
+      </DropdownMenu.Item>
+    </DropdownMenu.Content>
+  </DropdownMenu.Root>;
+}

--- a/src/app/components/AppMenu.tsx
+++ b/src/app/components/AppMenu.tsx
@@ -17,6 +17,7 @@ export function AppMenu({
   setTheme,
   setSettingsOpen,
   setShareOpen,
+  setImportOpen,
 }: {
   apiKeyReady: boolean,
   apiKey: string,
@@ -24,6 +25,7 @@ export function AppMenu({
   setTheme: (t: Theme) => void;
   setSettingsOpen: (b: boolean) => void;
   setShareOpen: (b: boolean) => void;
+  setImportOpen: (b: boolean) => void;
 }) {
   return <DropdownMenu.Root>
     <DropdownMenu.Trigger>
@@ -36,7 +38,7 @@ export function AppMenu({
                 className="absolute text-red-600 bg-surface rounded-full border border-surface"
                 style={{right: -4, top: -4}}
               />
-              <PiDotsThreeVerticalBold/>
+              <PiDotsThreeVerticalBold />
             </IconButton>
           </Tooltip>
         </div>
@@ -77,7 +79,7 @@ export function AppMenu({
         <PiLinkBold />
         Share...
       </DropdownMenu.Item>
-      <DropdownMenu.Item>
+      <DropdownMenu.Item onSelect={() => setImportOpen(true)}>
         <PiDownloadSimpleBold />
         Import / Export
       </DropdownMenu.Item>

--- a/src/app/components/AppMenu.tsx
+++ b/src/app/components/AppMenu.tsx
@@ -20,7 +20,7 @@ export function AppMenu({
   setTheme,
   setSettingsOpen,
   setShareOpen,
-  setImportOpen,
+  setImportExportOpen,
 }: {
   apiKeyReady: boolean;
   apiKey: string;
@@ -28,7 +28,7 @@ export function AppMenu({
   setTheme: (t: Theme) => void;
   setSettingsOpen: (b: boolean) => void;
   setShareOpen: (b: boolean) => void;
-  setImportOpen: (b: boolean) => void;
+  setImportExportOpen: (b: boolean) => void;
 }) {
   return (
     <DropdownMenu.Root>
@@ -88,7 +88,7 @@ export function AppMenu({
           <PiLinkBold />
           Share...
         </DropdownMenu.Item>
-        <DropdownMenu.Item onSelect={() => setImportOpen(true)}>
+        <DropdownMenu.Item onSelect={() => setImportExportOpen(true)}>
           <PiDownloadSimpleBold />
           Import / Export
         </DropdownMenu.Item>

--- a/src/app/components/AppMenu.tsx
+++ b/src/app/components/AppMenu.tsx
@@ -1,13 +1,13 @@
-import { DropdownMenu, Flex, IconButton, Tooltip } from "@radix-ui/themes";
+import { Button, DropdownMenu, Flex, Tooltip } from "@radix-ui/themes";
 import {
+  PiArrowSquareInBold,
   PiBellFill,
   PiCircleFill,
   PiCircleHalfBold,
-  PiDotsThreeVerticalBold,
-  PiDownloadSimpleBold,
   PiGearSixFill,
-  PiLinkBold,
+  PiList,
   PiMoonBold,
+  PiShareBold,
   PiSunBold,
 } from "react-icons/pi";
 import React from "react";
@@ -36,25 +36,34 @@ export function AppMenu({
         {apiKeyReady && !apiKey ? (
           <div>
             <Tooltip content="Enter an Access Token for improved functionality">
-              <IconButton
-                className="relative"
-                variant="outline"
+              <Button
+                variant="ghost"
                 radius="small"
-                size="1"
+                size="2"
+                style={{ marginRight: 0 }}
               >
-                <PiCircleFill
-                  size={11}
-                  className="absolute text-red-600 bg-surface rounded-full border border-surface"
-                  style={{ right: -4, top: -4 }}
-                />
-                <PiDotsThreeVerticalBold />
-              </IconButton>
+                <div className="relative mr-1">
+                  <PiCircleFill
+                    size={11}
+                    className="absolute text-red-600 bg-surface rounded-full border border-surface"
+                    style={{ right: -4, top: -4 }}
+                  />
+                  <PiList size={18} />
+                </div>
+                Menu
+              </Button>
             </Tooltip>
           </div>
         ) : (
-          <IconButton variant="outline" radius="small" size="1">
-            <PiDotsThreeVerticalBold />
-          </IconButton>
+          <Button
+            variant="ghost"
+            radius="small"
+            size="2"
+            style={{ marginRight: 0 }}
+          >
+            <PiList size={18} className="mr-1" />
+            Menu
+          </Button>
         )}
       </DropdownMenu.Trigger>
       <DropdownMenu.Content variant="soft">
@@ -85,11 +94,11 @@ export function AppMenu({
           </DropdownMenu.SubContent>
         </DropdownMenu.Sub>
         <DropdownMenu.Item onSelect={() => setShareOpen(true)}>
-          <PiLinkBold />
+          <PiShareBold />
           Share...
         </DropdownMenu.Item>
         <DropdownMenu.Item onSelect={() => setImportExportOpen(true)}>
-          <PiDownloadSimpleBold />
+          <PiArrowSquareInBold />
           Import / Export
         </DropdownMenu.Item>
         <DropdownMenu.Separator />

--- a/src/app/components/ArchetypesList.tsx
+++ b/src/app/components/ArchetypesList.tsx
@@ -5,7 +5,6 @@ import {
   PiCaretDownFill,
   PiCheck,
   PiPencilSimple,
-  PiUser,
   PiUserCircle,
 } from "react-icons/pi";
 import useApi from "@/app/hooks/useApi";
@@ -70,7 +69,7 @@ export default function ArchetypesList() {
             className="block text-nowrap overflow-hidden overflow-ellipsis"
             style={{ maxWidth: "calc(100vw - 120px - 20px - 20px)" }}
           >
-            <PiUserCircle className="inline-block mr-1" />
+            <PiUserCircle className="inline-block mr-1 mb-0.5" />
             {selectedArchetype?.name || "Current User"}
           </Link>
           <PiCaretDownFill className="ml-0.5 text-violet-a11" size={12} />

--- a/src/app/components/AttributesForm/index.tsx
+++ b/src/app/components/AttributesForm/index.tsx
@@ -258,13 +258,16 @@ export default function AttributesForm({
           ) : (
             <>
               <div
-                className="rt-TextAreaRoot rt-r-size-2 rt-variant-surface mb-2"
-                style={{ minHeight: "unset !important" }}
+                className={clsx(
+                  "rt-TextAreaRoot rt-r-size-2 rt-variant-surface mb-2",
+                  {
+                    "border border-red-700": textareaError,
+                  },
+                )}
+                style={{minHeight: "unset !important"}}
               >
                 <TextareaAutosize
-                  className={clsx("rt-reset rt-TextAreaInput mono", {
-                    "border-red-700": textareaError,
-                  })}
+                  className="rt-reset rt-TextAreaInput mono"
                   name={"__JSON_attributes__"}
                   value={textareaAttributes}
                   onChange={(e) => {

--- a/src/app/components/AttributesForm/index.tsx
+++ b/src/app/components/AttributesForm/index.tsx
@@ -264,7 +264,7 @@ export default function AttributesForm({
                     "border border-red-700": textareaError,
                   },
                 )}
-                style={{minHeight: "unset !important"}}
+                style={{ minHeight: "unset !important" }}
               >
                 <TextareaAutosize
                   className="rt-reset rt-TextAreaInput mono"

--- a/src/app/components/ExperimentDetail.tsx
+++ b/src/app/components/ExperimentDetail.tsx
@@ -1,5 +1,12 @@
 import { MW, NAV_H } from "@/app";
-import { Button, IconButton, Link, RadioCards } from "@radix-ui/themes";
+import {
+  Button,
+  Callout,
+  IconButton,
+  Link,
+  RadioCards,
+  Tooltip,
+} from "@radix-ui/themes";
 import {
   PiArrowSquareOut,
   PiCaretRightFill,
@@ -28,6 +35,7 @@ import { SelectedExperiment } from "@/app/components/ExperimentsTab";
 import { AutoExperimentVariation, isURLTargeted } from "@growthbook/growthbook";
 import clsx from "clsx";
 import DebugLogger, { DebugLogAccordion } from "@/app/components/DebugLogger";
+import { TbEyeSearch } from "react-icons/tb";
 
 export default function ExperimentDetail({
   selectedEid,
@@ -161,6 +169,21 @@ export default function ExperimentDetail({
         </div>
 
         <div className="content">
+          {selectedExperiment?.experiment?.isDraft ? (
+            <Callout.Root
+              color="cyan"
+              size="1"
+              className="py-1.5 px-2 mt-2 mb-4"
+            >
+              <Tooltip content="You are previewing a draft state of this experiment. Reload the current page to reset.">
+                <span className="text-sm">
+                  <TbEyeSearch className="inline-block mr-1 mb-0.5" />
+                  Previewing draft
+                </span>
+              </Tooltip>
+            </Callout.Root>
+          ) : null}
+
           <div className="my-1">
             <div className="mt-2 mb-3">
               <div className="label font-semibold">Enrollment Status</div>

--- a/src/app/components/ExperimentsTab.tsx
+++ b/src/app/components/ExperimentsTab.tsx
@@ -23,10 +23,12 @@ import { getFeatureDetails } from "@/app/components/FeaturesTab";
 import { ValueType } from "@/app/components/ValueField";
 import FeatureExperimentStatusIcon from "@/app/components/FeatureExperimentStatusIcon";
 import { useResponsiveContext } from "../hooks/useResponsive";
+import { TbEyeSearch } from "react-icons/tb";
 
 export type ExperimentWithFeatures = (AutoExperiment | Experiment<any>) & {
   features?: string[];
   featureTypes?: Record<string, ValueType>;
+  isDraft?: boolean;
 };
 
 export const LEFT_PERCENT = 0.4;
@@ -284,6 +286,12 @@ export default function ExperimentsTab() {
                     forced={isForced}
                     type="experiment"
                   />
+                  {selectedExperiment?.experiment?.isDraft ? (
+                    <TbEyeSearch
+                      className="inline-block mr-1 opacity-50"
+                      size={12}
+                    />
+                  ) : null}
                   {eid}
                 </div>
                 <div

--- a/src/app/components/FeatureDetail.tsx
+++ b/src/app/components/FeatureDetail.tsx
@@ -24,6 +24,7 @@ import useGlobalState from "@/app/hooks/useGlobalState";
 import { APP_ORIGIN, CLOUD_APP_ORIGIN } from "@/app/components/Settings";
 import useTabState from "@/app/hooks/useTabState";
 import DebugLogger from "@/app/components/DebugLogger";
+import { TbEyeSearch } from "react-icons/tb";
 
 export default function FeatureDetail({
   selectedFid,
@@ -134,6 +135,20 @@ export default function FeatureDetail({
         </div>
 
         <div className="content">
+          {selectedFeature?.feature?.isDraft ? (
+            <Callout.Root
+              color="cyan"
+              size="1"
+              className="py-1.5 px-2 mt-2 mb-4"
+            >
+              <Tooltip content="You are previewing a draft state of this feature. Reload the current page to reset.">
+                <span className="text-sm">
+                  <TbEyeSearch className="inline-block mr-1 mb-0.5" />
+                  Previewing draft
+                </span>
+              </Tooltip>
+            </Callout.Root>
+          ) : null}
           {selectedFeature?.feature?.noDefinition ? (
             <Callout.Root
               color="amber"

--- a/src/app/components/FeaturesTab.tsx
+++ b/src/app/components/FeaturesTab.tsx
@@ -25,10 +25,12 @@ import SearchBar from "@/app/components/SearchBar";
 import { Box, Button, Link, Switch, Tooltip } from "@radix-ui/themes";
 import FeatureExperimentStatusIcon from "@/app/components/FeatureExperimentStatusIcon";
 import { useResponsiveContext } from "../hooks/useResponsive";
+import { TbEyeSearch } from "react-icons/tb";
 
 export type FeatureDefinitionWithId = FeatureDefinition & {
   id: string;
   noDefinition?: boolean;
+  isDraft?: boolean;
 };
 
 export const LEFT_PERCENT = 0.4;
@@ -283,6 +285,12 @@ export default function FeaturesTab() {
                       forced={isForced}
                       type="feature"
                     />
+                    {selectedFeature?.feature?.isDraft ? (
+                      <TbEyeSearch
+                        className="inline-block mr-1 opacity-50"
+                        size={12}
+                      />
+                    ) : null}
                     {fid}
                   </div>
                 </div>

--- a/src/app/components/ImportExport.tsx
+++ b/src/app/components/ImportExport.tsx
@@ -108,15 +108,27 @@ const ImportExport = ({ close }: { close: () => void }) => {
 
   const importState = () => {
     try {
-      const payload = JSON.parse(formValue);
-      if (payload?.attributes && typeof payload.attributes === "object") {
-        setOverriddenAttributes(payload.attributes);
+      const data = JSON.parse(formValue);
+      if (data?.attributes && typeof data.attributes === "object") {
+        setOverriddenAttributes(data.attributes);
       }
-      if (payload?.features && typeof payload.features === "object") {
-        setForcedFeatures(payload.features);
+      if (data?.features && typeof data.features === "object") {
+        setForcedFeatures(data.features);
       }
-      if (payload?.experiments && typeof payload.experiments === "object") {
-        setForcedVariations(payload.experiments);
+      if (data?.experiments && typeof data.experiments === "object") {
+        setForcedVariations(data.experiments);
+      }
+      if (
+        data?.payload &&
+        typeof data.payload === "object"
+      ) {
+        chrome.runtime.sendMessage({ type: "SET_PAYLOAD", data: data.payload });
+      }
+      if (
+        data?.patchPayload &&
+        typeof data.patchPayload === "object"
+      ) {
+        chrome.runtime.sendMessage({ type: "PATCH_PAYLOAD", data: data.patchPayload });
       }
 
       setTextareaError(false);

--- a/src/app/components/ImportExport.tsx
+++ b/src/app/components/ImportExport.tsx
@@ -24,7 +24,7 @@ type StatePayload = {
 const ImportExport = ({ close }: { close: () => void }) => {
   const isDevtoolsPanel = useMemo(
     () =>
-      document.querySelector("#root")?.getAttribute("data-is-devtools") === "1",
+      document.querySelector("#root")?.getAttribute("data-is-devtools-panel") === "1",
     [],
   );
   const isFirefox = navigator.userAgent.includes("Firefox");

--- a/src/app/components/ImportExport.tsx
+++ b/src/app/components/ImportExport.tsx
@@ -1,14 +1,11 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Badge, Button, Checkbox, Link, Switch } from "@radix-ui/themes";
+import { Badge, Button, Checkbox, Link } from "@radix-ui/themes";
 import { useCopyToClipboard } from "@/app/hooks/useCopyToClipboard";
 import {
   PiArrowSquareInBold,
   PiArrowSquareOutBold,
   PiCaretRightFill,
   PiCheckBold,
-  PiDownloadSimpleBold,
-  PiLinkBold,
-  PiUploadSimpleBold,
 } from "react-icons/pi";
 import useTabState, { getActiveTabId } from "@/app/hooks/useTabState";
 import { Attributes } from "@growthbook/growthbook";

--- a/src/app/components/ImportExport.tsx
+++ b/src/app/components/ImportExport.tsx
@@ -8,7 +8,7 @@ import {
   PiLinkBold,
   PiUploadSimpleBold,
 } from "react-icons/pi";
-import useTabState from "@/app/hooks/useTabState";
+import useTabState, {getActiveTabId} from "@/app/hooks/useTabState";
 import { Attributes } from "@growthbook/growthbook";
 import { getOS } from "@/app/utils";
 import clsx from "clsx";
@@ -106,7 +106,7 @@ const ImportExport = ({ close }: { close: () => void }) => {
     }
   }, [statePayload, dirty]);
 
-  const importState = () => {
+  const importState = async () => {
     try {
       const data = JSON.parse(formValue);
       if (data?.attributes && typeof data.attributes === "object") {
@@ -122,13 +122,33 @@ const ImportExport = ({ close }: { close: () => void }) => {
         data?.payload &&
         typeof data.payload === "object"
       ) {
-        chrome.runtime.sendMessage({ type: "SET_PAYLOAD", data: data.payload });
+        const activeTabId = await getActiveTabId();
+        if (activeTabId) {
+          if (chrome?.tabs) {
+            await chrome.tabs.sendMessage(activeTabId, {
+              type: "SET_PAYLOAD",
+              data: data.payload,
+            });
+          } else {
+            chrome.runtime.sendMessage({type: "SET_PAYLOAD", data: data.payload});
+          }
+        }
       }
       if (
         data?.patchPayload &&
         typeof data.patchPayload === "object"
       ) {
-        chrome.runtime.sendMessage({ type: "PATCH_PAYLOAD", data: data.patchPayload });
+        const activeTabId = await getActiveTabId();
+        if (activeTabId) {
+          if (chrome?.tabs) {
+            await chrome.tabs.sendMessage(activeTabId, {
+              type: "PATCH_PAYLOAD",
+              data: data.patchPayload,
+            });
+          } else {
+            chrome.runtime.sendMessage({type: "PATCH_PAYLOAD", data: data.patchPayload});
+          }
+        }
       }
 
       setTextareaError(false);

--- a/src/app/components/ImportExport.tsx
+++ b/src/app/components/ImportExport.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useMemo, useState } from "react";
-import {Badge, Button, Checkbox, Link, Switch} from "@radix-ui/themes";
+import { Badge, Button, Checkbox, Link, Switch } from "@radix-ui/themes";
 import { useCopyToClipboard } from "@/app/hooks/useCopyToClipboard";
-import {PiCaretRightFill, PiCheckBold, PiDownloadSimpleBold, PiLinkBold, PiUploadSimpleBold} from "react-icons/pi";
+import {
+  PiCaretRightFill,
+  PiCheckBold,
+  PiDownloadSimpleBold,
+  PiLinkBold,
+  PiUploadSimpleBold,
+} from "react-icons/pi";
 import useTabState from "@/app/hooks/useTabState";
 import { Attributes } from "@growthbook/growthbook";
 import { getOS } from "@/app/utils";
@@ -133,22 +139,14 @@ const ImportExport = ({ close }: { close: () => void }) => {
   useEffect(() => {
     setTimeout(
       () => (document.querySelector("#stateField") as HTMLElement)?.focus(),
-      100,
+      400,
     );
   }, []);
 
   return (
     <div>
-      <div className="mt-1 text-gray-12 text-xs">
-        Import or export a DevTools session by copying and pasting the following data.
-      </div>
-
       <div className="my-4">
-        <Accordion.Root
-          className="accordion"
-          type="single"
-          collapsible
-        >
+        <Accordion.Root className="accordion" type="single" collapsible>
           <Accordion.Item value="advanced">
             <Accordion.Trigger className="trigger mb-0.5">
               <Link
@@ -161,7 +159,8 @@ const ImportExport = ({ close }: { close: () => void }) => {
                 color={dirty ? "gray" : undefined}
               >
                 <PiCaretRightFill className="caret mr-0.5" size={12} />
-                Export overrides <span className="text-xs">({overridesText})</span>
+                Export overrides{" "}
+                <span className="text-xs">({overridesText})</span>
               </Link>
             </Accordion.Trigger>
             <Accordion.Content
@@ -171,8 +170,7 @@ const ImportExport = ({ close }: { close: () => void }) => {
             >
               <div className="box py-1">
                 <div className="my-1">
-                  <label
-                    className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
+                  <label className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
                     <Checkbox
                       size="1"
                       checked={includeFeatures}
@@ -184,19 +182,14 @@ const ImportExport = ({ close }: { close: () => void }) => {
                         {numForcedFeatures}
                       </Badge>
                     ) : (
-                      <Badge
-                        color="gray"
-                        radius="full"
-                        variant="soft"
-                      >
+                      <Badge color="gray" radius="full" variant="soft">
                         none
                       </Badge>
                     )}
                   </label>
                 </div>
                 <div className="my-1">
-                  <label
-                    className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
+                  <label className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
                     <Checkbox
                       size="1"
                       checked={includeExperiments}
@@ -208,19 +201,14 @@ const ImportExport = ({ close }: { close: () => void }) => {
                         {numForcedVariations}
                       </Badge>
                     ) : (
-                      <Badge
-                        color="gray"
-                        radius="full"
-                        variant="soft"
-                      >
+                      <Badge color="gray" radius="full" variant="soft">
                         none
                       </Badge>
                     )}
                   </label>
                 </div>
                 <div className="my-1">
-                  <label
-                    className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
+                  <label className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
                     <Checkbox
                       size="1"
                       checked={includeAttributes}
@@ -232,11 +220,7 @@ const ImportExport = ({ close }: { close: () => void }) => {
                         {numAttributeOverrides}
                       </Badge>
                     ) : (
-                      <Badge
-                        color="gray"
-                        radius="full"
-                        variant="soft"
-                      >
+                      <Badge color="gray" radius="full" variant="soft">
                         none
                       </Badge>
                     )}
@@ -249,12 +233,15 @@ const ImportExport = ({ close }: { close: () => void }) => {
       </div>
 
       <div className="my-4">
-        <h2>{!dirty ? (
-          <>
-            Current State{" "}
-            <span className="text-xs">(Paste to import)</span>
-          </>
-        ) : "Import State"}</h2>
+        <h2>
+          {!dirty ? (
+            <>
+              Current State <span className="text-xs">(Paste to import)</span>
+            </>
+          ) : (
+            "Import State"
+          )}
+        </h2>
         <div
           className={clsx(
             "rt-TextAreaRoot rt-r-size-2 rt-variant-surface mt-1 mb-2",
@@ -262,11 +249,11 @@ const ImportExport = ({ close }: { close: () => void }) => {
               "border border-red-700": textareaError,
             },
           )}
-          style={{minHeight: "unset !important"}}
+          style={{ minHeight: "unset !important" }}
         >
           <TextareaAutosize
             className="rt-reset rt-TextAreaInput mono"
-            style={{fontSize: "12px", lineHeight: "16px", padding: "6px 6px"}}
+            style={{ fontSize: "12px", lineHeight: "16px", padding: "6px 6px" }}
             id="stateField"
             name={"__stateField__"}
             value={formValue}
@@ -279,64 +266,51 @@ const ImportExport = ({ close }: { close: () => void }) => {
             minRows={2}
           />
         </div>
-          {dirty ? (
-            <div className="flex items-center justify-end gap-3">
-              <Link
-                href="#"
-                size="2"
-                role="button"
-                onClick={cancelImport}
-              >
-                Cancel
-              </Link>
-              <Button
-                type="button"
-                size="2"
-                onClick={importState}
-                disabled={!dirty}
-              >
-                <PiDownloadSimpleBold />
-                Import
-              </Button>
-            </div>
-          ) : (
-            <>
-              {isDevtoolsPanel && !isFirefox ? (
-                <div className="text-gray-11 text-xs">
-                  Copy this data to export ({getOS() === "Mac" ? "⌘ + C" : "Ctrl + C"})
-                </div>
-              ) : (
-                <div className="flex items-center justify-end gap-3">
-                  {copySuccess ? (
-                    <Button
-                      size="2"
-                      className="w-[145px]"
-                    >
-                      <PiCheckBold/>
-                      Copied
-                    </Button>
-                  ) : (
-                    <Button
-                      size="2"
-                      className="w-[145px]"
-                      onClick={() => {
-                        if (!copySuccess) performCopy(formValue);
-                      }}
-                    >
-                      <PiUploadSimpleBold />
-                      Export (Copy)
-                    </Button>
-                  )}
-                </div>
-              )}
-            </>
-          )}
-      </div>
-
-      <div className="mt-8">
-        <Button size="3" className="w-full" variant="soft" onClick={close}>
-          Close
-        </Button>
+        {dirty ? (
+          <div className="flex items-center justify-end gap-3">
+            <Link href="#" size="2" role="button" onClick={cancelImport}>
+              Cancel
+            </Link>
+            <Button
+              type="button"
+              size="2"
+              onClick={importState}
+              disabled={!dirty}
+            >
+              <PiDownloadSimpleBold />
+              Import
+            </Button>
+          </div>
+        ) : (
+          <>
+            {isDevtoolsPanel && !isFirefox ? (
+              <div className="text-gray-11 text-xs">
+                Copy this data to export (
+                {getOS() === "Mac" ? "⌘ + C" : "Ctrl + C"})
+              </div>
+            ) : (
+              <div className="flex items-center justify-end gap-3">
+                {copySuccess ? (
+                  <Button size="2" className="w-[145px]">
+                    <PiCheckBold />
+                    Copied
+                  </Button>
+                ) : (
+                  <Button
+                    size="2"
+                    className="w-[145px]"
+                    onClick={() => {
+                      if (!copySuccess) performCopy(formValue);
+                    }}
+                  >
+                    <PiUploadSimpleBold />
+                    Export (Copy)
+                  </Button>
+                )}
+              </div>
+            )}
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/app/components/LogsList.tsx
+++ b/src/app/components/LogsList.tsx
@@ -158,8 +158,11 @@ export default function LogsList({
                       smTextSizeClass,
                     })}
                   >
-                    <div className="w-[20%] min-w-[70px] px-1 text-left text-nowrap text-ellipsis flex items-center">
-                      <PiCaretRightFill className="caret mr-0.5" size={12} />
+                    <div className="w-[20%] min-w-[70px] pr-2 text-left text-nowrap text-ellipsis flex items-center">
+                      <PiCaretRightFill
+                        className="caret mr-0.5 flex-shrink-0"
+                        size={12}
+                      />
                       <Text className={xsTextSizeClass}>
                         {formattedDateTime}
                       </Text>
@@ -174,6 +177,7 @@ export default function LogsList({
                         xsTextSizeClass,
                       )}
                     >
+                      {evt.source ? "＊" : ""}
                       {evt.logType}
                     </div>
                     <div
@@ -209,7 +213,11 @@ export default function LogsList({
                 </Accordion.Trigger>
                 <Accordion.Content>
                   <ValueField
-                    value={evt.details}
+                    value={
+                      evt.source
+                        ? { eventSource: evt.source, ...evt.details }
+                        : evt.details
+                    }
                     valueType="json"
                     jsonStringifySpaces={2}
                     maxHeight={120}

--- a/src/app/components/LogsTab.tsx
+++ b/src/app/components/LogsTab.tsx
@@ -1,5 +1,5 @@
 import { LogUnion } from "@growthbook/growthbook";
-import React, { useEffect } from "react";
+import React from "react";
 import useTabState from "../hooks/useTabState";
 import LogsList from "./LogsList";
 import { Link } from "@radix-ui/themes";

--- a/src/app/components/Rule.tsx
+++ b/src/app/components/Rule.tsx
@@ -13,7 +13,7 @@ import { EvaluatedFeature } from "@/app/hooks/useGBSandboxEval";
 import { DebugLog } from "devtools";
 import DebugLogger from "@/app/components/DebugLogger";
 import useGlobalState from "@/app/hooks/useGlobalState";
-import { isDark } from "@/app";
+import { isDark, Theme } from "@/app";
 
 type RuleType = "force" | "rollout" | "experiment" | "prerequisite";
 
@@ -271,7 +271,14 @@ export function ExperimentRule({
   namespace?: [string, number, number] | undefined;
   valueType?: ValueType;
 }) {
-  const [dark] = useGlobalState("dark", false, true);
+  const [theme, setTheme, themeReady] = useGlobalState<Theme>(
+    "theme",
+    "system",
+    true,
+  );
+  const dark = useMemo(() => {
+    return isDark(theme);
+  }, [theme, themeReady]);
 
   let appliedCoverage = coverage;
   let nsRange: number | undefined;

--- a/src/app/components/SdkTab/SdkItemPanel.tsx
+++ b/src/app/components/SdkTab/SdkItemPanel.tsx
@@ -1,11 +1,20 @@
 import React, { useEffect, useState } from "react";
-import { Button, Callout, Flex, IconButton, Link, Text } from "@radix-ui/themes";
+import {
+  Button,
+  Callout,
+  Flex,
+  IconButton,
+  Link,
+  Text,
+} from "@radix-ui/themes";
 import ValueField from "@/app/components/ValueField";
 import { MW, NAV_H } from "@/app";
 import {
   PiArrowsClockwise,
   PiArrowSquareOut,
-  PiCaretRightFill, PiWarningFill, PiWarningOctagonFill,
+  PiCaretRightFill,
+  PiWarningFill,
+  PiWarningOctagonFill,
   PiXBold,
 } from "react-icons/pi";
 import * as Accordion from "@radix-ui/react-accordion";
@@ -220,11 +229,7 @@ function statusPanel({
 
           <div className="mb-4">
             {!activeTabId && !refreshing ? (
-              <Callout.Root
-                color="red"
-                size="1"
-                className="mb-4"
-              >
+              <Callout.Root color="red" size="1" className="mb-4">
                 <Callout.Icon>
                   <PiWarningOctagonFill />
                 </Callout.Icon>
@@ -323,24 +328,23 @@ function versionPanel({
       {!version ? (
         <>
           <Text>
-            Unable to find your SDK version. This may indicate a version prior to 0.30.0.
+            Unable to find your SDK version. This may indicate a version prior
+            to 0.30.0.
           </Text>
           <div className="mt-4">
-            <Callout.Root
-              color="red"
-              size="1"
-              className="mt-2 mb-4"
-            >
+            <Callout.Root color="red" size="1" className="mt-2 mb-4">
               <Callout.Icon>
                 <PiWarningOctagonFill />
               </Callout.Icon>
               <Callout.Text>
-                Possibly using an unsupported legacy version of the SDK (&lt;0.30.0)
+                Possibly using an unsupported legacy version of the SDK
+                (&lt;0.30.0)
               </Callout.Text>
             </Callout.Root>
             <Text>
-              Versions prior to 0.30.0 are unsupported in DevTools. Additionally, versions prior to
-              0.23.0 are considered unstable. Consider updating to the latest version.
+              Versions prior to 0.30.0 are unsupported in DevTools.
+              Additionally, versions prior to 0.23.0 are considered unstable.
+              Consider updating to the latest version.
             </Text>
           </div>
         </>
@@ -352,11 +356,7 @@ function versionPanel({
           </Text>
           {paddedVersionString(version) < paddedVersionString("0.30.0") ? (
             <div className="mt-4">
-              <Callout.Root
-                color="red"
-                size="1"
-                className="mt-2 mb-4"
-              >
+              <Callout.Root color="red" size="1" className="mt-2 mb-4">
                 <Callout.Icon>
                   <PiWarningOctagonFill />
                 </Callout.Icon>
@@ -510,17 +510,11 @@ function payloadPanel({ hasPayload, payload }: SDKHealthCheckResult) {
     <>
       {!hasPayload ? (
         <>
-          <Callout.Root
-            color="amber"
-            size="1"
-            className="mb-4"
-          >
+          <Callout.Root color="amber" size="1" className="mb-4">
             <Callout.Icon>
               <PiWarningFill />
             </Callout.Icon>
-            <Callout.Text>
-              No payload present in your SDK
-            </Callout.Text>
+            <Callout.Text>No payload present in your SDK</Callout.Text>
           </Callout.Root>
           <Text as="div" size="2" weight="regular">
             Please check your implementation.

--- a/src/app/components/Settings.tsx
+++ b/src/app/components/Settings.tsx
@@ -12,7 +12,7 @@ export const API_KEY = `${NAMESPACE}-${VERSION}-api-key`;
 export const CLOUD_API_HOST = "https://api.growthbook.io";
 export const CLOUD_APP_ORIGIN = "https://app.growthbook.io";
 
-const SettingsForm = ({ close }: { close?: () => void }) => {
+const SettingsForm = ({ close }: { close: () => void; }) => {
   const [apiHost, setApiHost, apiHostReady] = useGlobalState(
     API_HOST,
     CLOUD_API_HOST,
@@ -40,7 +40,7 @@ const SettingsForm = ({ close }: { close?: () => void }) => {
     setApiHost(values.apiHost);
     setAppOrigin(values.appOrigin);
     setApiKey(values.apiKey);
-    close?.();
+    close();
   };
 
   useEffect(() => {

--- a/src/app/components/Settings.tsx
+++ b/src/app/components/Settings.tsx
@@ -12,7 +12,7 @@ export const API_KEY = `${NAMESPACE}-${VERSION}-api-key`;
 export const CLOUD_API_HOST = "https://api.growthbook.io";
 export const CLOUD_APP_ORIGIN = "https://app.growthbook.io";
 
-const SettingsForm = ({ close }: { close: () => void; }) => {
+const SettingsForm = ({ close }: { close: () => void }) => {
   const [apiHost, setApiHost, apiHostReady] = useGlobalState(
     API_HOST,
     CLOUD_API_HOST,

--- a/src/app/components/Share.tsx
+++ b/src/app/components/Share.tsx
@@ -18,7 +18,9 @@ type StatePayload = {
 const Share = ({ close }: { close: () => void }) => {
   const isDevtoolsPanel = useMemo(
     () =>
-      document.querySelector("#root")?.getAttribute("data-is-devtools-panel") === "1",
+      document
+        .querySelector("#root")
+        ?.getAttribute("data-is-devtools-panel") === "1",
     [],
   );
   const isFirefox = navigator.userAgent.includes("Firefox");
@@ -93,15 +95,6 @@ const Share = ({ close }: { close: () => void }) => {
     url,
   ]);
 
-  const overridesText = useMemo(() => {
-    let parts: string[] = [];
-    includeFeatures && parts.push("features");
-    includeExperiments && parts.push("experiments");
-    includeAttributes && parts.push("attributes");
-    if (!parts.length) return "none";
-    return parts.join(", ");
-  }, [includeFeatures, includeExperiments, includeAttributes]);
-
   const { performCopy, copySuccess } = useCopyToClipboard({
     timeout: 1500,
   });
@@ -124,7 +117,7 @@ const Share = ({ close }: { close: () => void }) => {
         Share your current session with other DevTools users
       </div>
 
-      <div className="my-4">
+      <div className="my-2">
         <Accordion.Root className="accordion" type="single" collapsible>
           <Accordion.Item value="advanced">
             <Accordion.Trigger className="trigger mb-0.5">
@@ -134,68 +127,67 @@ const Share = ({ close }: { close: () => void }) => {
                 className="text-left leading-3 hover:underline"
               >
                 <PiCaretRightFill className="caret mr-0.5" size={12} />
-                Share overrides{" "}
-                <span className="text-xs">({overridesText})</span>
+                Select which overrides to export
               </Link>
             </Accordion.Trigger>
             <Accordion.Content className="accordionInner overflow-hidden w-full">
               <div className="box py-1">
-                <div className="my-1">
+                <div className="flex justify-between items-center my-1">
                   <label className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
                     <Checkbox
                       size="1"
                       checked={includeFeatures}
                       onCheckedChange={(b) => setIncludeFeatures(!!b)}
                     />
-                    <span>Features</span>{" "}
-                    {numForcedFeatures > 0 ? (
-                      <Badge color="amber" radius="full">
-                        {numForcedFeatures}
-                      </Badge>
-                    ) : (
-                      <Badge color="gray" radius="full" variant="soft">
-                        none
-                      </Badge>
-                    )}
+                    <span>Features</span>
                   </label>
+                  {numForcedFeatures > 0 ? (
+                    <Badge color="amber" radius="medium">
+                      {numForcedFeatures}
+                    </Badge>
+                  ) : (
+                    <Badge color="gray" radius="medium" variant="soft">
+                      none
+                    </Badge>
+                  )}
                 </div>
-                <div className="my-1">
+                <div className="flex justify-between items-center my-1">
                   <label className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
                     <Checkbox
                       size="1"
                       checked={includeExperiments}
                       onCheckedChange={(b) => setIncludeExperiments(!!b)}
                     />
-                    <span>Experiments</span>{" "}
-                    {numForcedVariations > 0 ? (
-                      <Badge color="amber" radius="full">
-                        {numForcedVariations}
-                      </Badge>
-                    ) : (
-                      <Badge color="gray" radius="full" variant="soft">
-                        none
-                      </Badge>
-                    )}
+                    <span>Experiments</span>
                   </label>
+                  {numForcedVariations > 0 ? (
+                    <Badge color="amber" radius="medium">
+                      {numForcedVariations}
+                    </Badge>
+                  ) : (
+                    <Badge color="gray" radius="medium" variant="soft">
+                      none
+                    </Badge>
+                  )}
                 </div>
-                <div className="my-1">
+                <div className="flex justify-between items-center my-1">
                   <label className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
                     <Checkbox
                       size="1"
                       checked={includeAttributes}
                       onCheckedChange={(b) => setIncludeAttributes(!!b)}
                     />
-                    <span>Attributes</span>{" "}
-                    {numAttributeOverrides > 0 ? (
-                      <Badge color="amber" radius="full">
-                        {numAttributeOverrides}
-                      </Badge>
-                    ) : (
-                      <Badge color="gray" radius="full" variant="soft">
-                        none
-                      </Badge>
-                    )}
+                    <span>Attributes</span>
                   </label>
+                  {numAttributeOverrides > 0 ? (
+                    <Badge color="amber" radius="medium">
+                      {numAttributeOverrides}
+                    </Badge>
+                  ) : (
+                    <Badge color="gray" radius="medium" variant="soft">
+                      none
+                    </Badge>
+                  )}
                 </div>
               </div>
             </Accordion.Content>

--- a/src/app/components/Share.tsx
+++ b/src/app/components/Share.tsx
@@ -1,13 +1,11 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Badge, Button, Checkbox, Link, Switch } from "@radix-ui/themes";
+import { Badge, Button, Checkbox, Link } from "@radix-ui/themes";
 import { useCopyToClipboard } from "@/app/hooks/useCopyToClipboard";
 import { PiCaretRightFill, PiCheckBold, PiLinkBold } from "react-icons/pi";
 import useTabState from "@/app/hooks/useTabState";
 import { Attributes } from "@growthbook/growthbook";
 import { getOS } from "@/app/utils";
 import * as Accordion from "@radix-ui/react-accordion";
-import ValueField from "@/app/components/ValueField";
-import { NAV_H } from "@/app";
 
 type StatePayload = {
   features?: Record<string, any>;

--- a/src/app/components/Share.tsx
+++ b/src/app/components/Share.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useMemo, useState } from "react";
-import {Badge, Button, Checkbox, Link, Switch} from "@radix-ui/themes";
+import { Badge, Button, Checkbox, Link, Switch } from "@radix-ui/themes";
 import { useCopyToClipboard } from "@/app/hooks/useCopyToClipboard";
-import {PiCaretRightFill, PiCheckBold, PiLinkBold} from "react-icons/pi";
+import { PiCaretRightFill, PiCheckBold, PiLinkBold } from "react-icons/pi";
 import useTabState from "@/app/hooks/useTabState";
 import { Attributes } from "@growthbook/growthbook";
 import { getOS } from "@/app/utils";
 import * as Accordion from "@radix-ui/react-accordion";
 import ValueField from "@/app/components/ValueField";
-import {NAV_H} from "@/app";
+import { NAV_H } from "@/app";
 
 type StatePayload = {
   features?: Record<string, any>;
@@ -114,31 +114,34 @@ const Share = ({ close }: { close: () => void }) => {
   useEffect(() => {
     setTimeout(
       () => (document.querySelector("#shareLinkField") as HTMLElement)?.focus(),
-      100,
+      400,
     );
   }, []);
 
   return (
     <div>
-      <div className="mt-1 text-gray-12 text-xs">
-        Get a shareable link for your current DevTools session. Recipient must
-        have GrowthBook DevTools installed.
+      <div className="mt-1 text-gray-12 text-sm">
+        Share your current session with other DevTools users
       </div>
 
       <div className="my-4">
         <Accordion.Root className="accordion" type="single" collapsible>
           <Accordion.Item value="advanced">
             <Accordion.Trigger className="trigger mb-0.5">
-              <Link size="2" role="button" className="text-left leading-3 hover:underline">
+              <Link
+                size="2"
+                role="button"
+                className="text-left leading-3 hover:underline"
+              >
                 <PiCaretRightFill className="caret mr-0.5" size={12} />
-                Share overrides <span className="text-xs">({overridesText})</span>
+                Share overrides{" "}
+                <span className="text-xs">({overridesText})</span>
               </Link>
             </Accordion.Trigger>
             <Accordion.Content className="accordionInner overflow-hidden w-full">
               <div className="box py-1">
                 <div className="my-1">
-                  <label
-                    className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
+                  <label className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
                     <Checkbox
                       size="1"
                       checked={includeFeatures}
@@ -150,19 +153,14 @@ const Share = ({ close }: { close: () => void }) => {
                         {numForcedFeatures}
                       </Badge>
                     ) : (
-                      <Badge
-                        color="gray"
-                        radius="full"
-                        variant="soft"
-                      >
+                      <Badge color="gray" radius="full" variant="soft">
                         none
                       </Badge>
                     )}
                   </label>
                 </div>
                 <div className="my-1">
-                  <label
-                    className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
+                  <label className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
                     <Checkbox
                       size="1"
                       checked={includeExperiments}
@@ -174,19 +172,14 @@ const Share = ({ close }: { close: () => void }) => {
                         {numForcedVariations}
                       </Badge>
                     ) : (
-                      <Badge
-                        color="gray"
-                        radius="full"
-                        variant="soft"
-                      >
+                      <Badge color="gray" radius="full" variant="soft">
                         none
                       </Badge>
                     )}
                   </label>
                 </div>
                 <div className="my-1">
-                  <label
-                    className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
+                  <label className="inline-flex gap-2 text-sm items-center select-none cursor-pointer hover:text-violet-11">
                     <Checkbox
                       size="1"
                       checked={includeAttributes}
@@ -198,11 +191,7 @@ const Share = ({ close }: { close: () => void }) => {
                         {numAttributeOverrides}
                       </Badge>
                     ) : (
-                      <Badge
-                        color="gray"
-                        radius="full"
-                        variant="soft"
-                      >
+                      <Badge color="gray" radius="full" variant="soft">
                         none
                       </Badge>
                     )}
@@ -231,29 +220,27 @@ const Share = ({ close }: { close: () => void }) => {
         ) : null}
       </div>
 
-      <div className="mt-8">
-        {isDevtoolsPanel && !isFirefox ? (
-          <Button size="3" className="w-full" variant="soft" onClick={close}>
-            Close
-          </Button>
-        ) : copySuccess ? (
-          <Button size="3" className="w-full">
-            <PiCheckBold/>
-            Link copied
-          </Button>
-        ) : (
-          <Button
-            size="3"
-            className="w-full"
-            onClick={() => {
-              if (!copySuccess) performCopy(shareableLink);
-            }}
-          >
-            <PiLinkBold/>
-            Copy Link
-          </Button>
-        )}
-      </div>
+      {!isDevtoolsPanel || isFirefox ? (
+        <div className="mt-8">
+          {copySuccess ? (
+            <Button size="3" className="w-full">
+              <PiCheckBold />
+              Link copied
+            </Button>
+          ) : (
+            <Button
+              size="3"
+              className="w-full"
+              onClick={() => {
+                if (!copySuccess) performCopy(shareableLink);
+              }}
+            >
+              <PiLinkBold />
+              Copy Link
+            </Button>
+          )}
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/app/components/Share.tsx
+++ b/src/app/components/Share.tsx
@@ -1,0 +1,164 @@
+import React, {useEffect, useMemo, useState} from "react";
+import {Badge, Button, Switch} from "@radix-ui/themes";
+import {useCopyToClipboard} from "@/app/hooks/useCopyToClipboard";
+import {PiCheckBold, PiLinkBold} from "react-icons/pi";
+import useTabState from "@/app/hooks/useTabState";
+import {Attributes} from "@growthbook/growthbook";
+
+type StatePayload = {
+  features?: Record<string, any>;
+  experiments?: Record<string, number>;
+  attributes?: Record<string, any>;
+}
+
+const Share = ({ close }: { close: () => void; }) => {
+  const isDevtoolsPanel = useMemo(() => document.querySelector("#root")?.getAttribute("data-is-devtools") === "1", []);
+  const isFirefox = navigator.userAgent.includes("Firefox");
+
+  const [forcedFeatures, setForcedFeatures, forcedFeaturesReady] = useTabState<Record<string, any>>("forcedFeatures", {});
+  const [forcedVariations, setForcedVariations, forcedVariationsReady] = useTabState<Record<string, any>>("forcedVariations", {});
+  const [overriddenAttributes, setOverriddenAttributes, overriddenAttributesReady] = useTabState<Attributes>("overriddenAttributes", {});
+  const [url] = useTabState<string>("url", "");
+
+  const numForcedFeatures = Object.keys(forcedFeatures || {}).length;
+  const numForcedVariations = Object.keys(forcedVariations || {}).length;
+  const numAttributeOverrides = Object.keys(overriddenAttributes || {}).length;
+
+  const [includeFeatures, setIncludeFeatures] = useState(numForcedFeatures > 0);
+  const [includeExperiments, setIncludeExperiments] = useState(numForcedVariations > 0);
+  const [includeAttributes, setIncludeAttributes] = useState(numAttributeOverrides > 0);
+
+  useEffect(() => {
+    if (forcedFeaturesReady && forcedVariationsReady && overriddenAttributesReady) {
+      setIncludeFeatures(numForcedFeatures > 0);
+      setIncludeExperiments(numForcedVariations > 0);
+      setIncludeAttributes(numAttributeOverrides > 0);
+    }
+  }, [numForcedFeatures, numForcedVariations, numAttributeOverrides, forcedFeaturesReady, forcedVariationsReady, overriddenAttributesReady]);
+
+  const shareableLink = useMemo(() => {
+    if (!url) return "";
+    const payloadObj: StatePayload = {
+      ...(includeFeatures ? { features: forcedFeatures } : {}),
+      ...(includeExperiments ? { experiments: forcedVariations } : {}),
+      ...(includeAttributes ? { attributes: overriddenAttributes } : {}),
+    };
+    const payload = JSON.stringify(payloadObj);
+    let u = url;
+    try {
+      const urlObj = new URL(url);
+      urlObj.searchParams.set("_gbdebug", encodeURIComponent(payload));
+      u = urlObj.href;
+    } catch (e) {
+      console.error("Unable to create link", {url, payloadObj});
+    }
+    return u;
+  }, [includeFeatures, includeExperiments, includeAttributes, forcedFeatures, forcedVariations, overriddenAttributes, url])
+
+  const { performCopy, copySuccess } = useCopyToClipboard({
+    timeout: 1500,
+  });
+  useEffect(() => {
+    if (copySuccess) {
+      setTimeout(close, 1000);
+    }
+  }, [copySuccess]);
+
+  return (
+    <div>
+      <div className="mt-1 text-gray-12 text-xs">
+        Get a shareable link for your current DevTools session.
+        Recipient must have GrowthBook DevTools installed.
+      </div>
+
+      <div className="my-4">
+        <div className="text-md mb-2">
+          Share overrides for...
+        </div>
+        <div className="box">
+        <label className="my-1 flex gap-2 text-sm items-center select-none cursor-pointer">
+          <Switch
+            size="1"
+            checked={includeFeatures}
+            onCheckedChange={(b) => setIncludeFeatures(b)}
+          />
+          <span>Features</span>{" "}
+          {numForcedFeatures > 0 ? (
+            <Badge color="amber" radius="full">{numForcedFeatures}</Badge>
+          ): (
+            <Badge color="gray" radius="full" variant="soft" className="text-2xs">none</Badge>
+          )}
+        </label>
+        <label className="my-1 flex gap-2 text-sm items-center select-none cursor-pointer">
+          <Switch
+            size="1"
+            checked={includeExperiments}
+            onCheckedChange={(b) => setIncludeExperiments(b)}
+          />
+          <span>Experiments</span>{" "}
+          {numForcedVariations > 0 ? (
+            <Badge color="amber" radius="full">{numForcedVariations}</Badge>
+          ): (
+            <Badge color="gray" radius="full" variant="soft" className="text-2xs">none</Badge>
+          )}
+        </label>
+        <label className="my-1 flex gap-2 text-sm items-center select-none cursor-pointer">
+          <Switch
+            size="1"
+            checked={includeAttributes}
+            onCheckedChange={(b) => setIncludeAttributes(b)}
+          />
+          <span>Attributes</span>{" "}
+          {numAttributeOverrides > 0 ? (
+            <Badge color="amber" radius="full">{numAttributeOverrides}</Badge>
+          ): (
+            <Badge color="gray" radius="full" variant="soft" className="text-2xs">none</Badge>
+          )}
+        </label>
+        </div>
+      </div>
+
+      <div>
+        <div className="rt-TextFieldRoot rt-r-size-2 rt-variant-surface">
+          <input
+            className="rt-reset rt-TextFieldInput text-xs"
+            type="text"
+            value={shareableLink}
+            onFocus={(e) => e.target.select()}
+          />
+        </div>
+        {isDevtoolsPanel && !isFirefox ? (
+          <div className="text-gray-11 text-xs">Copy this link to share</div>
+        ) : null}
+      </div>
+
+      <div className="mt-8">
+        {isDevtoolsPanel && !isFirefox ? (
+          <Button size="3" className="w-full" variant="soft" onClick={close}>
+            Close
+          </Button>
+        ) :
+        copySuccess ? (
+          <Button size="3" className="w-full">
+            <PiCheckBold/>
+            Link copied
+          </Button>
+        ) : (
+          <Button
+            size="3"
+            className="w-full"
+            onClick={() => {
+              if (!copySuccess) performCopy(shareableLink);
+            }}
+          >
+            <PiLinkBold/>
+            Copy Link
+          </Button>
+        )}
+      </div>
+
+    </div>
+  );
+};
+
+export default Share;

--- a/src/app/components/Share.tsx
+++ b/src/app/components/Share.tsx
@@ -18,7 +18,7 @@ type StatePayload = {
 const Share = ({ close }: { close: () => void }) => {
   const isDevtoolsPanel = useMemo(
     () =>
-      document.querySelector("#root")?.getAttribute("data-is-devtools") === "1",
+      document.querySelector("#root")?.getAttribute("data-is-devtools-panel") === "1",
     [],
   );
   const isFirefox = navigator.userAgent.includes("Firefox");

--- a/src/app/components/ValueField.tsx
+++ b/src/app/components/ValueField.tsx
@@ -1,12 +1,13 @@
 import clsx from "clsx";
 import { PiCircleFill } from "react-icons/pi";
-import React, { CSSProperties } from "react";
+import React, { CSSProperties, useMemo } from "react";
 import { Prism } from "react-syntax-highlighter";
 import {
   ghcolors as codeThemeLight,
   a11yDark as codeThemeDark,
 } from "react-syntax-highlighter/dist/esm/styles/prism";
 import useGlobalState from "@/app/hooks/useGlobalState";
+import { isDark, Theme } from "@/app";
 
 export type ValueType = "string" | "number" | "boolean" | "json" | "unknown";
 
@@ -40,7 +41,14 @@ export default function ValueField({
   stringAsCode?: boolean;
   formatDefaultTypeAsConditionValue?: boolean;
 }) {
-  const [dark, setDark] = useGlobalState("dark", false, true);
+  const [theme, setTheme, themeReady] = useGlobalState<Theme>(
+    "theme",
+    "system",
+    true,
+  );
+  const dark = useMemo(() => {
+    return isDark(theme);
+  }, [theme, themeReady]);
 
   const formattedValue =
     value !== undefined

--- a/src/app/css/index.css
+++ b/src/app/css/index.css
@@ -71,6 +71,8 @@
 }
 .ModalBody {
   max-width: 400px;
+  max-height: calc(100vh - 60px);
+  overflow-y: auto;
 }
 .mono {
   font-family: monospace;

--- a/src/app/hooks/useCopyToClipboard.ts
+++ b/src/app/hooks/useCopyToClipboard.ts
@@ -28,19 +28,17 @@ export const useCopyToClipboard = ({
     } catch (e) {
       // devtools panel must send a message to embed_script
       const activeTabId = await getActiveTabId();
-      if (!activeTabId) {
-      }
-      if (chrome?.tabs) {
-        console.log("send 1", value);
-        await chrome.tabs.sendMessage(activeTabId, {
-          type: "COPY_TO_CLIPBOARD",
-          value,
-        });
-        setSuccess(true);
-      } else {
-        console.log("send 2", value);
-        await chrome.runtime.sendMessage({ type: "COPY_TO_CLIPBOARD", value });
-        setSuccess(true);
+      if (activeTabId) {
+        if (chrome?.tabs) {
+          await chrome.tabs.sendMessage(activeTabId, {
+            type: "COPY_TO_CLIPBOARD",
+            value,
+          });
+          setSuccess(true);
+        } else {
+          await chrome.runtime.sendMessage({type: "COPY_TO_CLIPBOARD", value});
+          setSuccess(true);
+        }
       }
     }
   };

--- a/src/app/hooks/useCopyToClipboard.ts
+++ b/src/app/hooks/useCopyToClipboard.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import {getActiveTabId} from "@/app/hooks/useTabState";
+
+type CopyToClipboardOptions = {
+  /**
+   * Optional delay to flip the success flag back to false. Useful for toggling UI elements.
+   * Pass -1 to not flip the success flag back.
+   * (default: -1)
+   */
+  timeout?: number;
+};
+
+type UseCopyToClipboard = {
+  copySuccess: boolean;
+  performCopy: (value: string) => void;
+};
+
+export const useCopyToClipboard = ({
+  timeout = -1,
+}: CopyToClipboardOptions): UseCopyToClipboard => {
+  const [success, setSuccess] = useState(false);
+
+  const performCopyToClipboard = async (value: string) => {
+    try {
+      // popup can copy the text immediately
+      await navigator.clipboard.writeText(value);
+      setSuccess(true);
+    } catch (e) {
+      // devtools panel must send a message to embed_script
+      const activeTabId = await getActiveTabId();
+      if (!activeTabId) {}
+      if (chrome?.tabs) {
+        console.log("send 1", value)
+        await chrome.tabs.sendMessage(activeTabId, {type: "COPY_TO_CLIPBOARD", value});
+        setSuccess(true);
+      } else {
+        console.log("send 2", value)
+        await chrome.runtime.sendMessage({type: "COPY_TO_CLIPBOARD", value});
+        setSuccess(true);
+      }
+    }
+  };
+
+  useEffect(
+    function flipSuccessAfterDelay() {
+      if (timeout === -1) return;
+
+      if (success) {
+        const timer = window.setTimeout(() => {
+          setSuccess(false);
+        }, timeout);
+
+        return () => {
+          window.clearTimeout(timer);
+        };
+      }
+    },
+    [success, timeout]
+  );
+
+  return {
+    copySuccess: success,
+    performCopy: performCopyToClipboard,
+  };
+};

--- a/src/app/hooks/useCopyToClipboard.ts
+++ b/src/app/hooks/useCopyToClipboard.ts
@@ -36,7 +36,10 @@ export const useCopyToClipboard = ({
           });
           setSuccess(true);
         } else {
-          await chrome.runtime.sendMessage({type: "COPY_TO_CLIPBOARD", value});
+          await chrome.runtime.sendMessage({
+            type: "COPY_TO_CLIPBOARD",
+            value,
+          });
           setSuccess(true);
         }
       }

--- a/src/app/hooks/useCopyToClipboard.ts
+++ b/src/app/hooks/useCopyToClipboard.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import {getActiveTabId} from "@/app/hooks/useTabState";
+import { getActiveTabId } from "@/app/hooks/useTabState";
 
 type CopyToClipboardOptions = {
   /**
@@ -28,14 +28,18 @@ export const useCopyToClipboard = ({
     } catch (e) {
       // devtools panel must send a message to embed_script
       const activeTabId = await getActiveTabId();
-      if (!activeTabId) {}
+      if (!activeTabId) {
+      }
       if (chrome?.tabs) {
-        console.log("send 1", value)
-        await chrome.tabs.sendMessage(activeTabId, {type: "COPY_TO_CLIPBOARD", value});
+        console.log("send 1", value);
+        await chrome.tabs.sendMessage(activeTabId, {
+          type: "COPY_TO_CLIPBOARD",
+          value,
+        });
         setSuccess(true);
       } else {
-        console.log("send 2", value)
-        await chrome.runtime.sendMessage({type: "COPY_TO_CLIPBOARD", value});
+        console.log("send 2", value);
+        await chrome.runtime.sendMessage({ type: "COPY_TO_CLIPBOARD", value });
         setSuccess(true);
       }
     }
@@ -55,7 +59,7 @@ export const useCopyToClipboard = ({
         };
       }
     },
-    [success, timeout]
+    [success, timeout],
   );
 
   return {

--- a/src/app/hooks/useTabState.ts
+++ b/src/app/hooks/useTabState.ts
@@ -58,8 +58,13 @@ export default function useTabState<T>(
     const listener = async (message: any, sender: any) => {
       const activeTabId = await getActiveTabId();
       const senderTabId = sender?.tab?.id ?? message?.tabId;
-      const shouldListen = activeTabId && senderTabId ? activeTabId === senderTabId : false;
-      if (shouldListen && message.type === "tabStateChanged" && message.property === property) {
+      const shouldListen =
+        activeTabId && senderTabId ? activeTabId === senderTabId : false;
+      if (
+        shouldListen &&
+        message.type === "tabStateChanged" &&
+        message.property === property
+      ) {
         // Missing value indicates no state found in tab store, keep default value
         if ("value" in message) {
           setState(message.value);

--- a/src/app/hooks/useTabState.ts
+++ b/src/app/hooks/useTabState.ts
@@ -57,7 +57,8 @@ export default function useTabState<T>(
     // Listener for content script state changes
     const listener = async (message: any, sender: any) => {
       const activeTabId = await getActiveTabId();
-      const shouldListen = activeTabId && sender?.tab?.id ? activeTabId === sender.tab.id : false;
+      const senderTabId = sender?.tab?.id ?? message?.tabId;
+      const shouldListen = activeTabId && senderTabId ? activeTabId === senderTabId : false;
       if (shouldListen && message.type === "tabStateChanged" && message.property === property) {
         // Missing value indicates no state found in tab store, keep default value
         if ("value" in message) {

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,24 +1,36 @@
 import "@/app/css/index.css";
-import {Dialog, IconButton, Select, Tabs, Theme, Tooltip,} from "@radix-ui/themes";
-import React, {useEffect, useRef, useState} from "react";
+import {
+  Dialog,
+  IconButton,
+  Select,
+  Tabs,
+  Theme,
+  Tooltip,
+} from "@radix-ui/themes";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import logo from "./logo.svg";
 import logoWhite from "./logo-white.svg";
 import useTabState from "@/app/hooks/useTabState";
-import SdkTab, {getSdkStatus} from "./components/SdkTab";
+import SdkTab, { getSdkStatus } from "./components/SdkTab";
 import AttributesTab from "./components/AttributesTab";
 import ExperimentsTab from "./components/ExperimentsTab";
 import FeaturesTab from "./components/FeaturesTab";
 import LogsTab from "./components/LogsTab";
-import SettingsForm, {API_KEY} from "@/app/components/Settings";
+import SettingsForm, { API_KEY } from "@/app/components/Settings";
 import useSdkData from "@/app/hooks/useSdkData";
-import {PiCircleFill, PiWarningFill, PiWarningOctagonFill, PiX,} from "react-icons/pi";
+import {
+  PiCircleFill,
+  PiWarningFill,
+  PiWarningOctagonFill,
+  PiX,
+} from "react-icons/pi";
 import ArchetypesList from "@/app/components/ArchetypesList";
 import useGlobalState from "@/app/hooks/useGlobalState";
 import ConditionalWrapper from "@/app/components/ConditionalWrapper";
-import {useResponsiveContext} from "./hooks/useResponsive";
-import {Archetype} from "@/app/gbTypes";
-import {Attributes} from "@growthbook/growthbook";
-import {AppMenu} from "@/app/components/AppMenu";
+import { useResponsiveContext } from "./hooks/useResponsive";
+import { Archetype } from "@/app/gbTypes";
+import { Attributes } from "@growthbook/growthbook";
+import { AppMenu } from "@/app/components/AppMenu";
 import Share from "@/app/components/Share";
 
 export const MW = 1200; // max-width
@@ -45,12 +57,9 @@ export const App = () => {
     "system",
     true,
   );
-  const [dark, setDark] = useGlobalState("dark", isDark(theme));
-  useEffect(() => {
-    if (themeReady && dark !== isDark(theme)) {
-      setDark(isDark(theme));
-    }
-  }, [theme, themeReady, dark]);
+  const dark = useMemo(() => {
+    return isDark(theme);
+  }, [theme, themeReady]);
 
   const [apiKey, setApiKey, apiKeyReady] = useGlobalState(API_KEY, "", true);
 
@@ -120,11 +129,11 @@ export const App = () => {
               <Tabs.List>
                 <div
                   className="flex items-center mx-auto w-full"
-                  style={{maxWidth: MW}}
+                  style={{ maxWidth: MW }}
                 >
-                  <div className="mx-2"/>
+                  <div className="mx-2" />
                   <Tabs.Trigger value="features">
-                    <NavLabel type="features" forcedFeatures={forcedFeatures}/>
+                    <NavLabel type="features" forcedFeatures={forcedFeatures} />
                   </Tabs.Trigger>
                   <Tabs.Trigger value="experiments">
                     <NavLabel
@@ -139,12 +148,12 @@ export const App = () => {
                     />
                   </Tabs.Trigger>
                   <Tabs.Trigger value="logs">
-                    <NavLabel type="logs"/>
+                    <NavLabel type="logs" />
                   </Tabs.Trigger>
                   <Tabs.Trigger value="sdkDebug">
-                    <NavLabel type="sdkDebug" sdkStatus={sdkStatus}/>
+                    <NavLabel type="sdkDebug" sdkStatus={sdkStatus} />
                   </Tabs.Trigger>
-                  <div className="flex-1"/>
+                  <div className="flex-1" />
                   <div className="flex items-center gap-2 flex-grow-0 flex-shrink-0">
                     <AppMenu
                       apiKeyReady={apiKeyReady}
@@ -156,7 +165,7 @@ export const App = () => {
                       setImportOpen={setImportOpen}
                     />
                   </div>
-                  <div className="mx-2"/>
+                  <div className="mx-2" />
                 </div>
               </Tabs.List>
             </Tabs.Root>
@@ -290,10 +299,7 @@ export const App = () => {
           </Dialog.Content>
         </Dialog.Root>
 
-        <Dialog.Root
-          open={shareOpen}
-          onOpenChange={(o) => setShareOpen(o)}
-        >
+        <Dialog.Root open={shareOpen} onOpenChange={(o) => setShareOpen(o)}>
           <Dialog.Content className="ModalBody">
             <Dialog.Title>Share DevTools State</Dialog.Title>
             <Share close={() => setShareOpen(false)} />
@@ -311,10 +317,7 @@ export const App = () => {
           </Dialog.Content>
         </Dialog.Root>
 
-        <Dialog.Root
-          open={importOpen}
-          onOpenChange={(o) => setImportOpen(o)}
-        >
+        <Dialog.Root open={importOpen} onOpenChange={(o) => setImportOpen(o)}>
           <Dialog.Content className="ModalBody">
             <Dialog.Title>Import / Export DevTools State</Dialog.Title>
             <Dialog.Close style={{ position: "absolute", top: 5, right: 5 }}>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -32,6 +32,7 @@ import { Archetype } from "@/app/gbTypes";
 import { Attributes } from "@growthbook/growthbook";
 import { AppMenu } from "@/app/components/AppMenu";
 import Share from "@/app/components/Share";
+import ImportExport from "@/app/components/ImportExport";
 
 export const MW = 1200; // max-width
 export const RESPONSIVE_W = 570; // small width mode
@@ -49,7 +50,7 @@ export const App = () => {
   const [currentTab, setCurrentTab] = useTabState("currentTab", "features");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
-  const [importOpen, setImportOpen] = useState(false);
+  const [importExportOpen, setImportExportOpen] = useState(false);
 
   const { isResponsive, isTiny } = useResponsiveContext();
   const [theme, setTheme, themeReady] = useGlobalState<Theme>(
@@ -162,7 +163,7 @@ export const App = () => {
                       setTheme={setTheme}
                       setSettingsOpen={setSettingsOpen}
                       setShareOpen={setShareOpen}
-                      setImportOpen={setImportOpen}
+                      setImportExportOpen={setImportExportOpen}
                     />
                   </div>
                   <div className="mx-2" />
@@ -253,7 +254,7 @@ export const App = () => {
                   setTheme={setTheme}
                   setSettingsOpen={setSettingsOpen}
                   setShareOpen={setShareOpen}
-                  setImportOpen={setImportOpen}
+                  setImportExportOpen={setImportExportOpen}
                 />
               </div>
             </div>
@@ -317,9 +318,10 @@ export const App = () => {
           </Dialog.Content>
         </Dialog.Root>
 
-        <Dialog.Root open={importOpen} onOpenChange={(o) => setImportOpen(o)}>
+        <Dialog.Root open={importExportOpen} onOpenChange={(o) => setImportExportOpen(o)}>
           <Dialog.Content className="ModalBody">
             <Dialog.Title>Import / Export DevTools State</Dialog.Title>
+            <ImportExport close={() => setImportExportOpen(false)} />
             <Dialog.Close style={{ position: "absolute", top: 5, right: 5 }}>
               <IconButton
                 color="gray"

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,45 +1,24 @@
 import "@/app/css/index.css";
-import {
-  Theme,
-  IconButton,
-  Dialog,
-  Tabs,
-  Tooltip,
-  Select,
-} from "@radix-ui/themes";
-import React, { useEffect, useRef, useState } from "react";
+import {Dialog, IconButton, Select, Tabs, Theme, Tooltip,} from "@radix-ui/themes";
+import React, {useEffect, useRef, useState} from "react";
 import logo from "./logo.svg";
 import logoWhite from "./logo-white.svg";
 import useTabState from "@/app/hooks/useTabState";
-import SdkTab, { getSdkStatus } from "./components/SdkTab";
+import SdkTab, {getSdkStatus} from "./components/SdkTab";
 import AttributesTab from "./components/AttributesTab";
 import ExperimentsTab from "./components/ExperimentsTab";
 import FeaturesTab from "./components/FeaturesTab";
 import LogsTab from "./components/LogsTab";
-import SettingsForm, { API_KEY } from "@/app/components/Settings";
+import SettingsForm, {API_KEY} from "@/app/components/Settings";
 import useSdkData from "@/app/hooks/useSdkData";
-import {
-  PiX,
-  PiCircleFill,
-  PiGearSixFill,
-  PiWarningFill,
-  PiWarningOctagonFill,
-  PiSunBold,
-  PiMoonBold,
-  PiCircleHalfBold, PiLinkBold,
-} from "react-icons/pi";
+import {PiCircleFill, PiWarningFill, PiWarningOctagonFill, PiX,} from "react-icons/pi";
 import ArchetypesList from "@/app/components/ArchetypesList";
 import useGlobalState from "@/app/hooks/useGlobalState";
 import ConditionalWrapper from "@/app/components/ConditionalWrapper";
-import { useResponsiveContext } from "./hooks/useResponsive";
-import { Archetype } from "@/app/gbTypes";
-import packageJson from "@growthbook/growthbook/package.json";
-import { Attributes } from "@growthbook/growthbook";
-
-const latestSdkVersion = packageJson.version;
-const latestSdkParts = latestSdkVersion.split(".");
-latestSdkParts[2] = "0";
-const latestMinorSdkVersion = latestSdkParts.join(".");
+import {useResponsiveContext} from "./hooks/useResponsive";
+import {Archetype} from "@/app/gbTypes";
+import {Attributes} from "@growthbook/growthbook";
+import {AppMenu} from "@/app/components/AppMenu";
 
 export const MW = 1200; // max-width
 export const RESPONSIVE_W = 570; // small width mode
@@ -56,6 +35,7 @@ export function isDark(theme: Theme): boolean {
 export const App = () => {
   const [currentTab, setCurrentTab] = useTabState("currentTab", "features");
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
 
   const { isResponsive, isTiny } = useResponsiveContext();
   const [theme, setTheme, themeReady] = useGlobalState<Theme>(
@@ -138,11 +118,11 @@ export const App = () => {
               <Tabs.List>
                 <div
                   className="flex items-center mx-auto w-full"
-                  style={{ maxWidth: MW }}
+                  style={{maxWidth: MW}}
                 >
-                  <div className="mx-2" />
+                  <div className="mx-2"/>
                   <Tabs.Trigger value="features">
-                    <NavLabel type="features" forcedFeatures={forcedFeatures} />
+                    <NavLabel type="features" forcedFeatures={forcedFeatures}/>
                   </Tabs.Trigger>
                   <Tabs.Trigger value="experiments">
                     <NavLabel
@@ -157,22 +137,23 @@ export const App = () => {
                     />
                   </Tabs.Trigger>
                   <Tabs.Trigger value="logs">
-                    <NavLabel type="logs" />
+                    <NavLabel type="logs"/>
                   </Tabs.Trigger>
                   <Tabs.Trigger value="sdkDebug">
-                    <NavLabel type="sdkDebug" sdkStatus={sdkStatus} />
+                    <NavLabel type="sdkDebug" sdkStatus={sdkStatus}/>
                   </Tabs.Trigger>
-                  <div className="flex-1" />
+                  <div className="flex-1"/>
                   <div className="flex items-center gap-2 flex-grow-0 flex-shrink-0">
-                    <ThemeButton />
-                    <LinkButton />
-                    <SettingsButton
+                    <AppMenu
                       apiKeyReady={apiKeyReady}
                       apiKey={apiKey}
+                      theme={theme}
+                      setTheme={setTheme}
                       setSettingsOpen={setSettingsOpen}
+                      setShareOpen={setShareOpen}
                     />
                   </div>
-                  <div className="mx-2" />
+                  <div className="mx-2"/>
                 </div>
               </Tabs.List>
             </Tabs.Root>
@@ -253,12 +234,13 @@ export const App = () => {
                 </Select.Content>
               </Select.Root>
               <div className="flex items-center gap-2 flex-grow-0 flex-shrink-0">
-                <ThemeButton />
-                <LinkButton />
-                <SettingsButton
+                <AppMenu
                   apiKeyReady={apiKeyReady}
                   apiKey={apiKey}
+                  theme={theme}
+                  setTheme={setTheme}
                   setSettingsOpen={setSettingsOpen}
+                  setShareOpen={setShareOpen}
                 />
               </div>
             </div>
@@ -290,6 +272,26 @@ export const App = () => {
           <Dialog.Content className="ModalBody">
             <Dialog.Title>Settings</Dialog.Title>
             <SettingsForm close={() => setSettingsOpen(false)} />
+            <Dialog.Close style={{ position: "absolute", top: 5, right: 5 }}>
+              <IconButton
+                color="gray"
+                highContrast
+                size="1"
+                variant="outline"
+                radius="full"
+              >
+                <PiX size={20} />
+              </IconButton>
+            </Dialog.Close>
+          </Dialog.Content>
+        </Dialog.Root>
+
+        <Dialog.Root
+          open={shareOpen}
+          onOpenChange={(o) => setShareOpen(o)}
+        >
+          <Dialog.Content className="ModalBody">
+            <Dialog.Title>Share or Import State</Dialog.Title>
             <Dialog.Close style={{ position: "absolute", top: 5, right: 5 }}>
               <IconButton
                 color="gray"
@@ -437,94 +439,4 @@ function NavLabel({
   }
 
   return null;
-}
-
-function SettingsButton({
-  apiKeyReady,
-  apiKey,
-  setSettingsOpen,
-}: {
-  apiKeyReady: boolean;
-  apiKey: string;
-  setSettingsOpen: (b: boolean) => void;
-}) {
-  return apiKeyReady && !apiKey ? (
-    <Tooltip content="Enter an Access Token for improved functionality">
-      <IconButton
-        className="relative"
-        variant="outline"
-        size="1"
-        onClick={() => setSettingsOpen(true)}
-      >
-        <PiCircleFill
-          size={9}
-          className="absolute text-red-600 bg-surface rounded-full border border-surface"
-          style={{ right: 1, top: 1 }}
-        />
-        <PiGearSixFill size={17} />
-      </IconButton>
-    </Tooltip>
-  ) : (
-    <IconButton
-      variant="outline"
-      size="1"
-      onClick={() => setSettingsOpen(true)}
-    >
-      <PiGearSixFill size={17} />
-    </IconButton>
-  );
-}
-
-function ThemeButton() {
-  const [theme, setTheme] = useGlobalState<Theme>("theme", "system", true);
-  return (
-    <Tooltip
-      side="bottom"
-      content={`Theme: ${
-        theme === "system"
-          ? "System default"
-          : theme === "dark"
-            ? "Dark"
-            : "Light"
-      }`}
-    >
-      <IconButton
-        variant="ghost"
-        style={{ margin: 0 }}
-        size="1"
-        onClick={() =>
-          setTheme(
-            theme === "system"
-              ? "light"
-              : theme === "light"
-                ? "dark"
-                : "system",
-          )
-        }
-      >
-        {theme === "system" ? (
-          <PiCircleHalfBold />
-        ) : theme === "dark" ? (
-          <PiMoonBold />
-        ) : (
-          <PiSunBold />
-        )}
-      </IconButton>
-    </Tooltip>
-  );
-}
-
-function LinkButton() {
-  return (
-    <Tooltip content="Share DevTools state">
-      <IconButton
-        className="relative"
-        variant="outline"
-        size="1"
-        onClick={() => {}}
-      >
-        <PiLinkBold size={17}/>
-      </IconButton>
-    </Tooltip>
-  );
 }

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -318,7 +318,10 @@ export const App = () => {
           </Dialog.Content>
         </Dialog.Root>
 
-        <Dialog.Root open={importExportOpen} onOpenChange={(o) => setImportExportOpen(o)}>
+        <Dialog.Root
+          open={importExportOpen}
+          onOpenChange={(o) => setImportExportOpen(o)}
+        >
           <Dialog.Content className="ModalBody">
             <Dialog.Title>Import / Export DevTools State</Dialog.Title>
             <ImportExport close={() => setImportExportOpen(false)} />

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -26,7 +26,7 @@ import {
   PiWarningOctagonFill,
   PiSunBold,
   PiMoonBold,
-  PiCircleHalfBold,
+  PiCircleHalfBold, PiLinkBold,
 } from "react-icons/pi";
 import ArchetypesList from "@/app/components/ArchetypesList";
 import useGlobalState from "@/app/hooks/useGlobalState";
@@ -165,6 +165,7 @@ export const App = () => {
                   <div className="flex-1" />
                   <div className="flex items-center gap-2 flex-grow-0 flex-shrink-0">
                     <ThemeButton />
+                    <LinkButton />
                     <SettingsButton
                       apiKeyReady={apiKeyReady}
                       apiKey={apiKey}
@@ -253,6 +254,7 @@ export const App = () => {
               </Select.Root>
               <div className="flex items-center gap-2 flex-grow-0 flex-shrink-0">
                 <ThemeButton />
+                <LinkButton />
                 <SettingsButton
                   apiKeyReady={apiKeyReady}
                   apiKey={apiKey}
@@ -507,6 +509,21 @@ function ThemeButton() {
         ) : (
           <PiSunBold />
         )}
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+function LinkButton() {
+  return (
+    <Tooltip content="Share DevTools state">
+      <IconButton
+        className="relative"
+        variant="outline"
+        size="1"
+        onClick={() => {}}
+      >
+        <PiLinkBold size={17}/>
       </IconButton>
     </Tooltip>
   );

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -19,6 +19,7 @@ import {useResponsiveContext} from "./hooks/useResponsive";
 import {Archetype} from "@/app/gbTypes";
 import {Attributes} from "@growthbook/growthbook";
 import {AppMenu} from "@/app/components/AppMenu";
+import Share from "@/app/components/Share";
 
 export const MW = 1200; // max-width
 export const RESPONSIVE_W = 570; // small width mode
@@ -36,6 +37,7 @@ export const App = () => {
   const [currentTab, setCurrentTab] = useTabState("currentTab", "features");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
 
   const { isResponsive, isTiny } = useResponsiveContext();
   const [theme, setTheme, themeReady] = useGlobalState<Theme>(
@@ -151,6 +153,7 @@ export const App = () => {
                       setTheme={setTheme}
                       setSettingsOpen={setSettingsOpen}
                       setShareOpen={setShareOpen}
+                      setImportOpen={setImportOpen}
                     />
                   </div>
                   <div className="mx-2"/>
@@ -241,6 +244,7 @@ export const App = () => {
                   setTheme={setTheme}
                   setSettingsOpen={setSettingsOpen}
                   setShareOpen={setShareOpen}
+                  setImportOpen={setImportOpen}
                 />
               </div>
             </div>
@@ -291,7 +295,28 @@ export const App = () => {
           onOpenChange={(o) => setShareOpen(o)}
         >
           <Dialog.Content className="ModalBody">
-            <Dialog.Title>Share or Import State</Dialog.Title>
+            <Dialog.Title>Share DevTools State</Dialog.Title>
+            <Share close={() => setShareOpen(false)} />
+            <Dialog.Close style={{ position: "absolute", top: 5, right: 5 }}>
+              <IconButton
+                color="gray"
+                highContrast
+                size="1"
+                variant="outline"
+                radius="full"
+              >
+                <PiX size={20} />
+              </IconButton>
+            </Dialog.Close>
+          </Dialog.Content>
+        </Dialog.Root>
+
+        <Dialog.Root
+          open={importOpen}
+          onOpenChange={(o) => setImportOpen(o)}
+        >
+          <Dialog.Content className="ModalBody">
+            <Dialog.Title>Import / Export DevTools State</Dialog.Title>
             <Dialog.Close style={{ position: "absolute", top: 5, right: 5 }}>
               <IconButton
                 color="gray"

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -2,3 +2,12 @@
 export function isDefined<T>(x: T | undefined | null): x is T {
   return x !== undefined && x !== null;
 }
+
+export function getOS() {
+  const userAgent = navigator.userAgent;
+  if (userAgent.indexOf("Win") !== -1) return "Windows";
+  if (userAgent.indexOf("Mac") !== -1) return "Mac";
+  if (userAgent.indexOf("Linux") !== -1) return "Linux";
+  if (userAgent.indexOf("X11") !== -1) return "Unix";
+  return "Unknown";
+}

--- a/src/app/utils/logs.ts
+++ b/src/app/utils/logs.ts
@@ -5,10 +5,12 @@ export interface FlattenedLogEvent {
   logType: string;
   eventInfo: string;
   details: Record<string, unknown>;
+  source?: string;
 }
 export type LogType = LogUnion["logType"];
+export type LogUnionWithSource = LogUnion & { source?: string };
 
-export function reshapeEventLog(evt: LogUnion): FlattenedLogEvent {
+export function reshapeEventLog(evt: LogUnionWithSource): FlattenedLogEvent {
   switch (evt.logType) {
     case "event":
       return {
@@ -16,6 +18,7 @@ export function reshapeEventLog(evt: LogUnion): FlattenedLogEvent {
         logType: evt.logType,
         eventInfo: evt.eventName,
         details: evt.properties || {},
+        source: evt.source,
       };
     case "experiment":
       return {
@@ -26,6 +29,7 @@ export function reshapeEventLog(evt: LogUnion): FlattenedLogEvent {
           experiment: evt.experiment,
           result: evt.result,
         },
+        source: evt.source,
       };
     case "feature":
       return {
@@ -36,6 +40,7 @@ export function reshapeEventLog(evt: LogUnion): FlattenedLogEvent {
           featureKey: evt.featureKey,
           result: evt.result,
         },
+        source: evt.source,
       };
   }
 }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -95,9 +95,13 @@ chrome.runtime.onMessage.addListener((message, _, sendResponse) => {
 
       // Firefox: Proxied tab state messages (UI -> background -> content_script)
       if (
-        ["getTabState", "setTabState", "COPY_TO_CLIPBOARD", "SET_PAYLOAD", "PATCH_PAYLOAD"].includes(
-          message.type,
-        )
+        [
+          "getTabState",
+          "setTabState",
+          "COPY_TO_CLIPBOARD",
+          "SET_PAYLOAD",
+          "PATCH_PAYLOAD",
+        ].includes(message.type)
       ) {
         chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
           const activeTabId = tabs[0]?.id;

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -95,7 +95,7 @@ chrome.runtime.onMessage.addListener((message, _, sendResponse) => {
 
       // Firefox: Proxied tab state messages (UI -> background -> content_script)
       if (
-        ["getTabState", "setTabState", "COPY_TO_CLIPBOARD"].includes(
+        ["getTabState", "setTabState", "COPY_TO_CLIPBOARD", "SET_PAYLOAD", "PATCH_PAYLOAD"].includes(
           message.type,
         )
       ) {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -94,11 +94,18 @@ chrome.runtime.onMessage.addListener((message, _, sendResponse) => {
       }
 
       // Firefox: Proxied tab state messages (UI -> background -> content_script)
-      if (["getTabState", "setTabState", "COPY_TO_CLIPBOARD"].includes(message.type)) {
+      if (
+        ["getTabState", "setTabState", "COPY_TO_CLIPBOARD"].includes(
+          message.type,
+        )
+      ) {
         chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
           const activeTabId = tabs[0]?.id;
           if (activeTabId) {
-            chrome.tabs.sendMessage(activeTabId, {...message, tabId: activeTabId});
+            chrome.tabs.sendMessage(activeTabId, {
+              ...message,
+              tabId: activeTabId,
+            });
           }
         });
       }
@@ -190,9 +197,9 @@ const UpdateTabIconBasedOnSDK = (
             : "") +
           (!data.payloadDecrypted ? "Decryption issues\n" : "")) +
         (paddedVersionString(data.version) <
-           paddedVersionString(latestMinorSdkVersion)
-            ? "Outdated SDK version"
-            : "");
+        paddedVersionString(latestMinorSdkVersion)
+          ? "Outdated SDK version"
+          : "");
     } else {
       chrome.action.setIcon({
         tabId,
@@ -206,8 +213,8 @@ const UpdateTabIconBasedOnSDK = (
         (data.canConnect && !data.version
           ? "Unknown SDK version"
           : data.canConnect &&
-            paddedVersionString(data.version) <
-              paddedVersionString(latestMinorSdkVersion)
+              paddedVersionString(data.version) <
+                paddedVersionString(latestMinorSdkVersion)
             ? "Outdated SDK version"
             : "");
     }
@@ -285,7 +292,8 @@ export function getSdkStatus(
     !sdkData.hasPayload ||
     sdkData.trackingCallbackParams?.length !== 2 ||
     !sdkData.payloadDecrypted ||
-    paddedVersionString(sdkData.version) < paddedVersionString(latestMinorSdkVersion)
+    paddedVersionString(sdkData.version) <
+      paddedVersionString(latestMinorSdkVersion)
   ) {
     return "yellow";
   }
@@ -298,7 +306,10 @@ chrome.runtime.onMessage.addListener((message) => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       const activeTabId = tabs[0]?.id;
       if (activeTabId) {
-        chrome.tabs.sendMessage(activeTabId, {type: "SET_TAB_ID", tabId: activeTabId});
+        chrome.tabs.sendMessage(activeTabId, {
+          type: "SET_TAB_ID",
+          tabId: activeTabId,
+        });
       }
     });
   }

--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -152,6 +152,12 @@ function setupListeners() {
       case "GB_REQUEST_REFRESH":
         pushAppUpdates();
         break;
+      case "COPY_TO_CLIPBOARD":
+        if (message.value) {
+          window.focus();
+          navigator.clipboard.writeText(message.value);
+        }
+        break;
       default:
         return;
     }

--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -78,7 +78,7 @@ function hydrateApp() {
     pullOverrides();
     return;
   }
-  
+
   onGrowthBookLoad((gb) => {
     if (hydratedState?.attributes && Object.keys(hydratedState?.attributes || {}).length) {
       gb?.setAttributeOverrides?.(hydratedState.attributes);

--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -104,14 +104,18 @@ function hydrateApp() {
     }
 
     if (
-      hydratedState?.payloadPatch &&
-      typeof hydratedState.payloadPatch === "object"
+      hydratedState?.patchPayload &&
+      typeof hydratedState.patchPayload === "object"
     ) {
-      patchPayload(hydratedState.payloadPatch);
+      patchPayload(hydratedState.patchPayload);
     }
 
     // logs are imported by hydration only
     if (hydratedState?.logs && Array.isArray(hydratedState.logs)) {
+      const logs = hydratedState.logs.map((log: any) => ({
+        ...log,
+        source: log.source ? log.source : "external",
+      }));
       updateTabState("logEvents", hydratedState.logs, true);
     }
   });

--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -73,6 +73,9 @@ function init() {
 }
 
 function pushAppUpdates() {
+  const urlState = getQueryState();
+  console.log({urlState});
+  
   updateTabState("url", window.location.href || "");
   onGrowthBookLoad((gb) => {
     pushSDKUpdate(gb);
@@ -488,6 +491,21 @@ async function SDKHealthCheck(gb?: GrowthBook): Promise<SDKHealthCheckResult> {
     errorMessage:
       res?.error || !!clientKey ? undefined : "No Client Key was found",
   };
+}
+
+export function getQueryState() {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const state = params.get("_gbdebug");
+    if (!state) return null;
+    const data = JSON.parse(decodeURIComponent(state));
+    params.delete("_gbdebug");
+    window.history.replaceState(null, "", window.location.pathname + (params.toString() ? "?" + params.toString() : ""));
+    return data;
+  } catch (e) {
+    console.error("Failed to parse query state", e);
+    return null;
+  }
 }
 
 // start running

--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -81,21 +81,18 @@ function hydrateApp() {
 
   onGrowthBookLoad((gb) => {
     if (
-      hydratedState?.attributes &&
-      Object.keys(hydratedState?.attributes || {}).length
+      hydratedState?.attributes && typeof hydratedState.attributes === "object"
     ) {
       gb?.setAttributeOverrides?.(hydratedState.attributes);
     }
     if (
-      hydratedState?.features &&
-      Object.keys(hydratedState?.features || {}).length
+      hydratedState?.features && typeof hydratedState.features === "object"
     ) {
       let forcedFeaturesMap = new Map(Object.entries(hydratedState.features));
       gb?.setForcedFeatures?.(forcedFeaturesMap);
     }
     if (
-      hydratedState?.experiments &&
-      Object.keys(hydratedState?.experiments || {}).length
+      hydratedState?.experiments && typeof hydratedState.experiments === "object"
     ) {
       gb?.setForcedVariations?.(hydratedState.experiments);
     }

--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -268,13 +268,13 @@ function patchPayload(data: FeatureApiResponse) {
       );
 
       if (gb.setPayload) {
-        gb.setPayload(data);
+        gb.setPayload(payload);
       } else {
-        if (gb.setFeatures && data.features) {
-          gb.setFeatures(data.features);
+        if (gb.setFeatures && payload.features) {
+          gb.setFeatures(payload.features);
         }
-        if (gb.setExperiments && data.experiments) {
-          gb.setExperiments(data.experiments);
+        if (gb.setExperiments && payload.experiments) {
+          gb.setExperiments(payload.experiments);
         }
       }
     }

--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -99,10 +99,7 @@ function hydrateApp() {
       gb?.setForcedVariations?.(hydratedState.experiments);
     }
 
-    if (
-      hydratedState?.payload &&
-      typeof hydratedState.payload === "object"
-    ) {
+    if (hydratedState?.payload && typeof hydratedState.payload === "object") {
       setPayload(hydratedState.payload);
     }
 
@@ -252,20 +249,18 @@ function patchPayload(data: FeatureApiResponse) {
         features: gb.getFeatures?.(),
         experiments: gb.getExperiments?.(),
       };
-      Object.keys(data).forEach(
-        (key) => {
-          const k = key as keyof FeatureApiResponse;
-          if (!payload[k]) {
+      Object.keys(data).forEach((key) => {
+        const k = key as keyof FeatureApiResponse;
+        if (!payload[k]) {
+          // @ts-ignore
+          payload[k] = data[k];
+        } else {
+          if (typeof payload[k] === "object") {
             // @ts-ignore
-            payload[k] = data[k];
-          } else {
-            if (typeof payload[k] === "object") {
-              // @ts-ignore
-              payload[k] = { ...payload[k], ...data[k] };
-            }
+            payload[k] = { ...payload[k], ...data[k] };
           }
-        },
-      );
+        }
+      });
 
       if (gb.setPayload) {
         gb.setPayload(payload);

--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -80,15 +80,24 @@ function hydrateApp() {
   }
 
   onGrowthBookLoad((gb) => {
-    if (hydratedState?.attributes && Object.keys(hydratedState?.attributes || {}).length) {
+    if (
+      hydratedState?.attributes &&
+      Object.keys(hydratedState?.attributes || {}).length
+    ) {
       gb?.setAttributeOverrides?.(hydratedState.attributes);
     }
-    if (hydratedState?.forcedFeatures && Object.keys(hydratedState?.forcedFeatures || {}).length) {
-      let forcedFeaturesMap = new Map(Object.entries(hydratedState.forcedFeatures));
+    if (
+      hydratedState?.features &&
+      Object.keys(hydratedState?.features || {}).length
+    ) {
+      let forcedFeaturesMap = new Map(Object.entries(hydratedState.features));
       gb?.setForcedFeatures?.(forcedFeaturesMap);
     }
-    if (hydratedState?.forcedVariations && Object.keys(hydratedState?.forcedVariations || {}).length) {
-      gb?.setForcedVariations?.(hydratedState.forcedVariations);
+    if (
+      hydratedState?.experiments &&
+      Object.keys(hydratedState?.experiments || {}).length
+    ) {
+      gb?.setForcedVariations?.(hydratedState.experiments);
     }
   });
 }
@@ -426,8 +435,8 @@ async function SDKHealthCheck(gb?: GrowthBook): Promise<SDKHealthCheckResult> {
   };
   const hasPayload =
     !!gb.getDecryptedPayload?.() ||
-    (Object.keys(gb.getFeatures?.() || {}).length > 0 ||
-      (gb.getExperiments?.() || []).length > 0);
+    Object.keys(gb.getFeatures?.() || {}).length > 0 ||
+    (gb.getExperiments?.() || []).length > 0;
   // check if payload was decrypted
   const hasDecryptionKey = !!gbContext?.decryptionKey;
   let payloadDecrypted = true;
@@ -449,8 +458,7 @@ async function SDKHealthCheck(gb?: GrowthBook): Promise<SDKHealthCheckResult> {
 
   const onFeatureUsage = gbContext?.onFeatureUsage;
   const usingOnFeatureUsage =
-    typeof onFeatureUsage === "function" &&
-    !onFeatureUsage.isNoopCallback;
+    typeof onFeatureUsage === "function" && !onFeatureUsage.isNoopCallback;
 
   const isRemoteEval = !!gb.isRemoteEval?.();
 
@@ -533,7 +541,12 @@ export function getQueryState() {
     const decoded = decodeURIComponent(state);
     const data = JSON.parse(decoded);
     params.delete("_gbdebug");
-    window.history.replaceState(null, "", window.location.pathname + (params.toString() ? "?" + params.toString() : ""));
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname +
+        (params.toString() ? "?" + params.toString() : ""),
+    );
     return data;
   } catch (e) {
     console.error("Failed to parse query state", e);

--- a/src/content_script/index.ts
+++ b/src/content_script/index.ts
@@ -179,6 +179,10 @@ chrome.runtime.onMessage.addListener(async (msg: Message) => {
     case "COPY_TO_CLIPBOARD":
       window.postMessage(msg, window.location.origin);
       break;
+    case "SET_PAYLOAD":
+    case "PATCH_PAYLOAD":
+      window.postMessage(msg, window.location.origin);
+      break;
     default:
       break;
   }

--- a/src/content_script/index.ts
+++ b/src/content_script/index.ts
@@ -231,5 +231,5 @@ if (navigator.userAgent.includes("Firefox")) {
       tabId = message.tabId;
     }
   });
-  chrome.runtime.sendMessage({action: "GET_TAB_ID"});
+  chrome.runtime.sendMessage({ action: "GET_TAB_ID" });
 }

--- a/src/content_script/index.ts
+++ b/src/content_script/index.ts
@@ -43,9 +43,13 @@ window.addEventListener(
         (Array.isArray(currentValue) || currentValue === undefined || !success)
       ) {
         if (currentValue === undefined || !success) {
-          setState(property, [value], true);
+          setState(property, Array.isArray(value) ? value : [value], true);
         } else {
-          setState(property, [...currentValue, value], true);
+          setState(
+            property,
+            [...currentValue, ...(Array.isArray(value) ? value : [value])],
+            true,
+          );
         }
       } else {
         setState(property, value, true);


### PR DESCRIPTION
Ability to import and export devtools / SDK state

blob format (namespaced by `_gbdebug`. ex: `?_gbdebug=...`):
```
{
  // embed script and payload blobs
  attributes?: Record<string, any>; // overrides
  forcedFeatures?: Record<string, any>; // feature value overrides
  forcedVariations?: Record<string, number>; // variation overrides
  payload, // import only. "remote" eval?
  patchPayload, // import only. preview drafts

  // embed script hydration only
  logs, // import only. for inspecting things that happened on the backend
}
```

import by
- [x] querystring blob / shareable link
- [ ] SSR-generated JSON \<script\> (needs further spike)
- [ ] GB API response header (needs further spike)
- [x] paste state blob into devtools

export to
- [x] querystring blob on current page / shareable link
- [x] blob for copy/paste into devtools