### PR TITLE
Fix runtime crashes and scope CSP violations with severity.

### DIFF
--- a/devtools.d.ts
+++ b/devtools.d.ts
@@ -22,6 +22,11 @@ export type CopyMode = "energetic" | "concise" | "humorous";
 
 export type CSPError = {
   violatedDirective: string;
+  effectiveDirective?: string;
+  blockedURI?: string;
+  sourceFile?: string;
+  isFatal?: boolean;
+  timestamp?: number;
 };
 
 export interface VisualEditorVariation {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
-    "@growthbook/growthbook": "^1.5.0",
+    "@growthbook/growthbook": "^1.6.5",
     "@medv/finder": "^3.2.0",
     "@phosphor-icons/react": "^2.1.7",
     "@radix-ui/colors": "^3.0.0",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -87,6 +87,7 @@ chrome.runtime.onMessage.addListener((message, _, sendResponse) => {
             // not found, send empty message to signal unset
           });
         }
+        sendResponse({ success: true });
       }
       if (message.type === "setGlobalState") {
         await setState(message.property, message.value, message.persist);

--- a/src/content_script/index.ts
+++ b/src/content_script/index.ts
@@ -124,6 +124,7 @@ chrome.runtime.onMessage.addListener((message, _, sendResponse) => {
           // not found, send empty message to signal unset
         });
       }
+      sendResponse({ success: true });
     }
     if (message.type === "setTabState") {
       setState(message.property, message.value); // Update the state property
@@ -202,10 +203,10 @@ if (!document.getElementById(DEVTOOLS_SCRIPT_ID)) {
 
 // Inject visual editor content script
 const VISUAL_EDITOR_SCRIPT_ID = "visual-editor-script";
-if (
-  !document.getElementById(VISUAL_EDITOR_SCRIPT_ID) &&
-  (!!loadVisualEditorQueryParams() || forceLoadVisualEditor)
-) {
+const shouldInjectVisualEditor =
+  !!loadVisualEditorQueryParams() || forceLoadVisualEditor;
+const injectVisualEditorScript = () => {
+  if (document.getElementById(VISUAL_EDITOR_SCRIPT_ID)) return;
   const script = document.createElement("script");
   script.id = VISUAL_EDITOR_SCRIPT_ID;
   script.async = true;
@@ -213,6 +214,16 @@ if (
   script.src = chrome.runtime.getURL("js/visual_editor.js");
 
   document.body.appendChild(script);
+};
+
+if (shouldInjectVisualEditor) {
+  if (document.readyState === "complete") {
+    injectVisualEditorScript();
+  } else {
+    window.addEventListener("load", injectVisualEditorScript, {
+      once: true,
+    });
+  }
 }
 // check if the storage has been removed and reload the data from embed script
 window.addEventListener("storage", (event) => {

--- a/src/visual_editor/components/ErrorDisplay.tsx
+++ b/src/visual_editor/components/ErrorDisplay.tsx
@@ -2,19 +2,41 @@ import React, { useRef, FC, useEffect } from "react";
 import { CSPError } from "../../../devtools";
 
 const CSPErrorDisplay = ({ cspError }: { cspError: CSPError | null }) => (
-  <div className="p-4 text-red-400">
-    The {cspError ? `${cspError.violatedDirective} directive in the` : ""}{" "}
-    Content Security Policy on this page is too strict for the Visual Editor.
-    Refer to the Visual Editor documentation's{" "}
-    <a
-      className="underline"
-      href="https://docs.growthbook.io/app/visual#security-requirements"
-      target="_blank"
-      rel="noreferrer"
-    >
-      'Security Requirements'
-    </a>{" "}
-    for details.
+  <div className={cspError?.isFatal ? "p-4 text-red-400" : "p-4 text-amber-300"}>
+    <p className="mb-2">
+      {cspError?.isFatal ? "Critical CSP restriction" : "CSP warning"}:{" "}
+      {cspError
+        ? `${cspError.effectiveDirective || cspError.violatedDirective}`
+        : "Unknown directive"}
+      .
+    </p>
+    {!cspError?.isFatal ? (
+      <p className="text-sm">
+        Some site scripts were blocked by CSP. Visual Editor should stay active.
+      </p>
+    ) : (
+      <p className="text-sm">
+        Extension resources required by Visual Editor were blocked.
+      </p>
+    )}
+    <p className="text-xs mt-2 break-all">
+      Blocked URI: {cspError?.blockedURI || "unknown"}
+    </p>
+    <p className="text-xs mt-1 break-all">
+      Source: {cspError?.sourceFile || "unknown"}
+    </p>
+    <p className="text-xs mt-2">
+      Refer to{" "}
+      <a
+        className="underline"
+        href="https://docs.growthbook.io/app/visual#security-requirements"
+        target="_blank"
+        rel="noreferrer"
+      >
+        Visual Editor Security Requirements
+      </a>
+      .
+    </p>
   </div>
 );
 
@@ -23,6 +45,10 @@ interface ErrorDisplayProps {
   cspError: CSPError | null;
 }
 const ErrorDisplay: FC<ErrorDisplayProps> = ({ error, cspError }) => {
+  if (cspError && !cspError.isFatal && error !== "csp-error") {
+    return <CSPErrorDisplay cspError={cspError} />;
+  }
+
   switch (error) {
     case "no-api-host":
     case "no-api-key":
@@ -52,15 +78,16 @@ const ErrorDisplay: FC<ErrorDisplayProps> = ({ error, cspError }) => {
 export default (props: ErrorDisplayProps) => {
   const { error, cspError } = props;
   const errorContainerRef = useRef<HTMLDivElement | null>(null);
+  const shouldAutoScroll = !!error || !!cspError?.isFatal;
 
   // scroll to error
   useEffect(() => {
-    if (!error && !cspError && !errorContainerRef.current) return;
+    if (!shouldAutoScroll) return;
     errorContainerRef.current?.scrollIntoView({
       behavior: "smooth",
       block: "end",
     });
-  }, [error, cspError, errorContainerRef.current]);
+  }, [shouldAutoScroll]);
 
   return (
     <div ref={errorContainerRef}>

--- a/src/visual_editor/components/ErrorDisplay.tsx
+++ b/src/visual_editor/components/ErrorDisplay.tsx
@@ -45,7 +45,7 @@ interface ErrorDisplayProps {
   cspError: CSPError | null;
 }
 const ErrorDisplay: FC<ErrorDisplayProps> = ({ error, cspError }) => {
-  if (cspError && !cspError.isFatal && error !== "csp-error") {
+  if (cspError && !cspError.isFatal && !error) {
     return <CSPErrorDisplay cspError={cspError} />;
   }
 

--- a/src/visual_editor/index.tsx
+++ b/src/visual_editor/index.tsx
@@ -1,5 +1,7 @@
 import { debounce } from "lodash";
 import React, {
+  Component,
+  ErrorInfo,
   FC,
   useCallback,
   useEffect,
@@ -47,7 +49,7 @@ import DebugPanel from "./components/DebugPanel";
 
 import VisualEditorCss from "./shadowDom.css";
 import "./targetPage.css";
-import { isGlobalObserverPaused, resumeGlobalObserver } from "dom-mutator";
+import { isGlobalObserverPaused } from "dom-mutator";
 
 const VisualEditor: FC<{}> = () => {
   const { x, y, setX, setY, parentStyles } = useFixedPositioning({
@@ -170,6 +172,10 @@ const VisualEditor: FC<{}> = () => {
       (selectedVariation?.css ? 1 : 0),
     [selectedVariation],
   );
+  const issueError = error || aiError;
+  const hasNonFatalCspWarning = !!cspError && !cspError.isFatal && !issueError;
+  const hasIssues = !!issueError || !!cspError;
+  const issuesCount = (issueError ? 1 : 0) + (cspError ? 1 : 0);
 
   useEffect(() => {
     if (!variations.length) return;
@@ -336,8 +342,14 @@ const VisualEditor: FC<{}> = () => {
           </VisualEditorSection>
         )}
 
-        {error || aiError ? (
-          <ErrorDisplay error={error || aiError} cspError={cspError} />
+        {hasIssues ? (
+          <VisualEditorSection
+            title={`Issues (${issuesCount})`}
+            isCollapsible
+            isExpanded={!hasNonFatalCspWarning}
+          >
+            <ErrorDisplay error={issueError} cspError={cspError} />
+          </VisualEditorSection>
         ) : null}
 
         <div className="m-4 text-center">
@@ -401,27 +413,160 @@ const VisualEditor: FC<{}> = () => {
   );
 };
 
+type VisualEditorErrorBoundaryProps = {
+  onRetry: () => void;
+  children: React.ReactNode;
+};
+type VisualEditorErrorBoundaryState = {
+  hasError: boolean;
+  message: string;
+};
+
+class VisualEditorErrorBoundary extends Component<
+  VisualEditorErrorBoundaryProps,
+  VisualEditorErrorBoundaryState
+> {
+  state: VisualEditorErrorBoundaryState = {
+    hasError: false,
+    message: "",
+  };
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, message: error?.message || "Unknown error" };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    window.postMessage(
+      {
+        type: "GB_ERROR",
+        error: `visual-editor-crash: ${error?.message || "Unknown error"}; ${info.componentStack || ""}`,
+      },
+      window.location.origin,
+    );
+  }
+
+  private retry = () => {
+    this.setState({ hasError: false, message: "" });
+    this.props.onRetry();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="rounded-xl shadow-xl z-max w-80 bg-dark p-4 text-red-400">
+          <p className="text-sm mb-2">Visual Editor hit a runtime error.</p>
+          <p className="text-xs mb-3 break-words">{this.state.message}</p>
+          <button
+            className="bg-slate-600 text-slate-100 px-3 py-1 rounded text-xs"
+            onClick={this.retry}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 /**
  * mounting the visual editor
  */
 export const CONTAINER_ID = "__gb_visual_editor";
 
-const container = document.createElement("div");
-container.id = CONTAINER_ID;
+export let shadowRoot: ShadowRoot | null = null;
+let root: ReactDOM.Root | null = null;
+let mountObserver: MutationObserver | null = null;
+let remountTimeout: number | null = null;
+let remountCount = 0;
+let remountWindowStart = 0;
+const REMOUNT_WINDOW_MS = 10000;
+const MAX_REMOUNTS_PER_WINDOW = 5;
 
-export const shadowRoot = container?.attachShadow({ mode: "open" });
+const isNodeAttached = (node: Node | null) =>
+  !!node && document.documentElement.contains(node);
 
-if (shadowRoot) {
-  shadowRoot.innerHTML = `
-    <style>${VisualEditorCss}</style>
-    <div id="visual-editor-root"></div>
-  `;
-}
+const scheduleRemount = () => {
+  const now = Date.now();
+  if (now - remountWindowStart > REMOUNT_WINDOW_MS) {
+    remountWindowStart = now;
+    remountCount = 0;
+  }
+  if (remountCount >= MAX_REMOUNTS_PER_WINDOW) return;
+  remountCount += 1;
 
-document.body.appendChild(container);
+  if (remountTimeout) window.clearTimeout(remountTimeout);
+  remountTimeout = window.setTimeout(() => {
+    ensureVisualEditorMounted();
+  }, 150);
+};
 
-const root = ReactDOM.createRoot(
-  shadowRoot.querySelector("#visual-editor-root")!,
-);
+const getContainer = () =>
+  document.getElementById(CONTAINER_ID) as HTMLDivElement | null;
 
-root.render(<VisualEditor />);
+const ensureVisualEditorMounted = () => {
+  let container = getContainer();
+  if (!container || !isNodeAttached(container)) {
+    container = document.createElement("div");
+    container.id = CONTAINER_ID;
+    document.body.appendChild(container);
+  }
+
+  if (!container.shadowRoot) {
+    shadowRoot = container.attachShadow({ mode: "open" });
+    shadowRoot.innerHTML = `
+      <style>${VisualEditorCss}</style>
+      <div id="visual-editor-root"></div>
+    `;
+    root = null;
+  } else {
+    shadowRoot = container.shadowRoot;
+    if (!shadowRoot.querySelector("#visual-editor-root")) {
+      shadowRoot.innerHTML = `
+        <style>${VisualEditorCss}</style>
+        <div id="visual-editor-root"></div>
+      `;
+      root = null;
+    }
+  }
+
+  const mountNode = shadowRoot?.querySelector("#visual-editor-root");
+  if (!mountNode) return;
+
+  if (!root) {
+    root = ReactDOM.createRoot(mountNode);
+  }
+  root.render(
+    <VisualEditorErrorBoundary onRetry={() => ensureVisualEditorMounted()}>
+      <VisualEditor />
+    </VisualEditorErrorBoundary>,
+  );
+
+  if (!mountObserver) {
+    mountObserver = new MutationObserver(() => {
+      const currentContainer = getContainer();
+      if (!currentContainer || !isNodeAttached(currentContainer)) {
+        scheduleRemount();
+      }
+    });
+    mountObserver.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+  }
+};
+
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "visible") {
+    ensureVisualEditorMounted();
+  }
+});
+
+window.addEventListener("pagehide", () => {
+  if (remountTimeout) {
+    window.clearTimeout(remountTimeout);
+    remountTimeout = null;
+  }
+});
+
+ensureVisualEditorMounted();

--- a/src/visual_editor/lib/csp.test.ts
+++ b/src/visual_editor/lib/csp.test.ts
@@ -1,0 +1,33 @@
+import { classifyCSPViolation } from "./csp";
+
+const eventFactory = (
+  overrides: Partial<SecurityPolicyViolationEvent> = {},
+): SecurityPolicyViolationEvent =>
+  ({
+    violatedDirective: "script-src",
+    effectiveDirective: "script-src",
+    blockedURI: "https://www.googletagmanager.com/gtm.js",
+    sourceFile: "https://example.com/demo",
+    ...overrides,
+  }) as SecurityPolicyViolationEvent;
+
+describe("classifyCSPViolation", () => {
+  it("returns non-fatal for third-party blocked scripts", () => {
+    const result = classifyCSPViolation(eventFactory());
+    expect(result.isRelevant).toBe(true);
+    expect(result.isFatal).toBe(false);
+    expect(result.details.isFatal).toBe(false);
+  });
+
+  it("returns fatal for blocked extension resources", () => {
+    const result = classifyCSPViolation(
+      eventFactory({
+        blockedURI: "chrome-extension://abc123/js/visual_editor.js",
+      }),
+    );
+    expect(result.isRelevant).toBe(true);
+    expect(result.isFatal).toBe(true);
+    expect(result.details.isFatal).toBe(true);
+  });
+});
+

--- a/src/visual_editor/lib/csp.ts
+++ b/src/visual_editor/lib/csp.ts
@@ -1,0 +1,60 @@
+import { CSPError } from "devtools";
+
+const VE_RELEVANT_DIRECTIVES = new Set([
+  "script-src",
+  "script-src-elem",
+  "style-src",
+  "style-src-elem",
+  "connect-src",
+]);
+
+const EXTENSION_URI_PREFIXES = ["chrome-extension://", "moz-extension://"];
+
+const isExtensionUri = (value?: string | null) => {
+  if (!value) return false;
+  return EXTENSION_URI_PREFIXES.some((prefix) => value.startsWith(prefix));
+};
+
+const toSafeValue = (value?: string | null) => value || "";
+
+export const classifyCSPViolation = (
+  e: Pick<
+    SecurityPolicyViolationEvent,
+    "violatedDirective" | "effectiveDirective" | "blockedURI" | "sourceFile"
+  >,
+): {
+  isRelevant: boolean;
+  isFatal: boolean;
+  key: string;
+  details: CSPError;
+} => {
+  const effectiveDirective = toSafeValue(e.effectiveDirective);
+  const violatedDirective = toSafeValue(e.violatedDirective);
+  const blockedURI = toSafeValue(e.blockedURI);
+  const sourceFile = toSafeValue(e.sourceFile);
+
+  const normalizedDirective =
+    effectiveDirective || violatedDirective || "unknown";
+  const isRelevant = VE_RELEVANT_DIRECTIVES.has(normalizedDirective);
+  const blockedExtensionResource =
+    isExtensionUri(blockedURI) || isExtensionUri(sourceFile);
+
+  // Fatal when extension-owned resources are explicitly blocked.
+  const isFatal = isRelevant && blockedExtensionResource;
+  const details: CSPError = {
+    violatedDirective,
+    effectiveDirective: normalizedDirective,
+    blockedURI,
+    sourceFile,
+    isFatal,
+    timestamp: Date.now(),
+  };
+
+  return {
+    isRelevant,
+    isFatal,
+    key: `${normalizedDirective}|${blockedURI}|${sourceFile}`,
+    details,
+  };
+};
+

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -10,6 +10,7 @@ import { VisualEditorVariation } from "devtools";
 import { Attribute } from "@/visual_editor/components/AttributeEdit";
 import getSelector from "@/visual_editor/lib/getSelector";
 import { CONTAINER_ID } from "@/visual_editor";
+import { waitForHydrationSafe } from "@/visual_editor/lib/hydration";
 
 export const hoverAttributeName = "edit-mode-hover";
 
@@ -308,6 +309,18 @@ const useEditMode: UseEditModeHook = ({
   // upon every DOM mutation, we revert all changes and replay them to ensure
   // that the DOM is in the correct state
   const mutateRevert = useRef<(() => void) | null>(null);
+  const [hydrationSafe, setHydrationSafe] = useState(false);
+  const pendingMutationsRef = useRef<VisualEditorVariation["domMutations"]>();
+
+  useEffect(() => {
+    let cancelled = false;
+    waitForHydrationSafe().then(() => {
+      if (!cancelled) setHydrationSafe(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const runMutations = (
     domMutations?: VisualEditorVariation["domMutations"],
@@ -330,8 +343,19 @@ const useEditMode: UseEditModeHook = ({
   };
 
   useEffect(() => {
+    if (!hydrationSafe) {
+      pendingMutationsRef.current = variation?.domMutations;
+      return;
+    }
     runMutations(variation?.domMutations);
-  }, [variation]);
+  }, [variation, hydrationSafe]);
+
+  useEffect(() => {
+    if (!hydrationSafe) return;
+    if (!pendingMutationsRef.current) return;
+    runMutations(pendingMutationsRef.current);
+    pendingMutationsRef.current = undefined;
+  }, [hydrationSafe]);
 
   const hasTextInChildren = (element: Element) => {
     for (let child of element.children) {

--- a/src/visual_editor/lib/hooks/useEditMode.ts
+++ b/src/visual_editor/lib/hooks/useEditMode.ts
@@ -310,7 +310,6 @@ const useEditMode: UseEditModeHook = ({
   // that the DOM is in the correct state
   const mutateRevert = useRef<(() => void) | null>(null);
   const [hydrationSafe, setHydrationSafe] = useState(false);
-  const pendingMutationsRef = useRef<VisualEditorVariation["domMutations"]>();
 
   useEffect(() => {
     let cancelled = false;
@@ -343,19 +342,9 @@ const useEditMode: UseEditModeHook = ({
   };
 
   useEffect(() => {
-    if (!hydrationSafe) {
-      pendingMutationsRef.current = variation?.domMutations;
-      return;
-    }
+    if (!hydrationSafe) return;
     runMutations(variation?.domMutations);
   }, [variation, hydrationSafe]);
-
-  useEffect(() => {
-    if (!hydrationSafe) return;
-    if (!pendingMutationsRef.current) return;
-    runMutations(pendingMutationsRef.current);
-    pendingMutationsRef.current = undefined;
-  }, [hydrationSafe]);
 
   const hasTextInChildren = (element: Element) => {
     for (let child of element.children) {

--- a/src/visual_editor/lib/hooks/useGhostElement.ts
+++ b/src/visual_editor/lib/hooks/useGhostElement.ts
@@ -11,12 +11,25 @@ type UseGhostElementHook = (args: {
 const cloneElement = (element: HTMLElement) => {
   const clone = element.cloneNode(true) as HTMLElement;
   const computedStyles = window.getComputedStyle(element);
+  const isSvgClone = clone instanceof SVGElement;
 
   for (let i = 0; i < computedStyles.length; i++) {
     const styleProperty = computedStyles[i];
+    const styleValue = computedStyles.getPropertyValue(styleProperty);
+
+    // Browsers may map these to SVG presentation attributes, where "auto"
+    // is invalid and logs errors like: <svg> attribute height: Expected length.
+    if (
+      isSvgClone &&
+      (styleProperty === "height" || styleProperty === "width") &&
+      styleValue.trim() === "auto"
+    ) {
+      continue;
+    }
+
     clone.style.setProperty(
       styleProperty,
-      computedStyles.getPropertyValue(styleProperty),
+      styleValue,
     );
   }
 

--- a/src/visual_editor/lib/hooks/useVisualChangeset.ts
+++ b/src/visual_editor/lib/hooks/useVisualChangeset.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   CSPError,
   VisualEditorVariation,
@@ -9,6 +9,7 @@ import {
   UpdateVisualChangesetRequestMessage,
 } from "devtools";
 import normalizeVariations from "../normalizeVariations";
+import { classifyCSPViolation } from "../csp";
 type UseVisualChangesetHook = (visualChangesetId: string) => {
   loading: boolean;
   experimentUrl: string | null;
@@ -36,14 +37,29 @@ const useVisualChangeset: UseVisualChangesetHook = (visualChangesetId) => {
   const [experiment, setExperiment] = useState<APIExperiment | null>(null);
   const [experimentUrl, setExperimentUrl] = useState<string | null>(null);
   const [variations, setVariations] = useState<VisualEditorVariation[]>([]);
+  const cspEventTimestamps = useRef<Record<string, number>>({});
 
-  document.addEventListener("securitypolicyviolation", (e) => {
-    if (e.violatedDirective !== "script-src") return;
-    setError("csp-error");
-    setCSPError({
-      violatedDirective: e.violatedDirective,
-    });
-  });
+  useEffect(() => {
+    const cspHandler = (e: SecurityPolicyViolationEvent) => {
+      const classification = classifyCSPViolation(e);
+      if (!classification.isRelevant) return;
+
+      // Deduplicate noisy CSP events for 2 seconds.
+      const now = Date.now();
+      const lastSeen = cspEventTimestamps.current[classification.key] || 0;
+      if (now - lastSeen < 2000) return;
+      cspEventTimestamps.current[classification.key] = now;
+
+      setCSPError(classification.details);
+      if (classification.isFatal) {
+        setError("csp-error");
+      }
+    };
+
+    document.addEventListener("securitypolicyviolation", cspHandler);
+    return () =>
+      document.removeEventListener("securitypolicyviolation", cspHandler);
+  }, []);
 
   const updateVisualChangeset = useCallback(
     async (variations: VisualEditorVariation[]) => {

--- a/src/visual_editor/lib/hydration.test.ts
+++ b/src/visual_editor/lib/hydration.test.ts
@@ -1,0 +1,81 @@
+import { waitForHydrationSafe } from "./hydration";
+
+class MockMutationObserver {
+  callback: MutationCallback;
+  constructor(callback: MutationCallback) {
+    this.callback = callback;
+  }
+  observe() {
+    // no-op
+  }
+  disconnect() {
+    // no-op
+  }
+}
+
+type ListenerMap = Record<string, Array<() => void>>;
+
+describe("waitForHydrationSafe", () => {
+  const listeners: ListenerMap = {};
+  let readyState = "loading";
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    readyState = "loading";
+
+    const mockWindow = {
+      setTimeout,
+      clearTimeout,
+      addEventListener: (event: string, cb: () => void) => {
+        listeners[event] = listeners[event] || [];
+        listeners[event].push(cb);
+      },
+      removeEventListener: (event: string, cb: () => void) => {
+        listeners[event] = (listeners[event] || []).filter((fn) => fn !== cb);
+      },
+    };
+    const mockDocument = {
+      get readyState() {
+        return readyState;
+      },
+      documentElement: {},
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).window = mockWindow;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).document = mockDocument;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).MutationObserver = MockMutationObserver;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    Object.keys(listeners).forEach((k) => delete listeners[k]);
+  });
+
+  it("waits until load event when document is still loading", async () => {
+    const promise = waitForHydrationSafe({
+      quietWindowMs: 30,
+      maxWaitMs: 200,
+    });
+
+    readyState = "complete";
+    (listeners.load || []).forEach((cb) => cb());
+    jest.advanceTimersByTime(35);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("resolves after quiet window when page is already complete", async () => {
+    readyState = "complete";
+    const promise = waitForHydrationSafe({
+      quietWindowMs: 20,
+      maxWaitMs: 200,
+    });
+
+    jest.advanceTimersByTime(25);
+    await expect(promise).resolves.toBeUndefined();
+  });
+});
+

--- a/src/visual_editor/lib/hydration.ts
+++ b/src/visual_editor/lib/hydration.ts
@@ -1,0 +1,71 @@
+type HydrationWaitOptions = {
+  quietWindowMs?: number;
+  maxWaitMs?: number;
+};
+
+const DEFAULT_QUIET_MS = 300;
+const DEFAULT_MAX_WAIT_MS = 5000;
+
+export const waitForHydrationSafe = ({
+  quietWindowMs = DEFAULT_QUIET_MS,
+  maxWaitMs = DEFAULT_MAX_WAIT_MS,
+}: HydrationWaitOptions = {}): Promise<void> => {
+  return new Promise((resolve) => {
+    const finish = () => resolve();
+
+    const waitForLoad = (onLoaded: () => void) => {
+      if (document.readyState === "complete") {
+        onLoaded();
+        return;
+      }
+
+      const onLoad = () => {
+        window.removeEventListener("load", onLoad);
+        onLoaded();
+      };
+      window.addEventListener("load", onLoad, { once: true });
+    };
+
+    waitForLoad(() => {
+      let quietTimer: number | null = null;
+      let maxTimer: number | null = null;
+      let observer: MutationObserver | null = null;
+      let done = false;
+
+      const cleanup = () => {
+        if (done) return;
+        done = true;
+        if (quietTimer) window.clearTimeout(quietTimer);
+        if (maxTimer) window.clearTimeout(maxTimer);
+        observer?.disconnect();
+      };
+
+      const resolveOnce = () => {
+        cleanup();
+        finish();
+      };
+
+      const scheduleQuiet = () => {
+        if (quietTimer) window.clearTimeout(quietTimer);
+        quietTimer = window.setTimeout(resolveOnce, quietWindowMs);
+      };
+
+      maxTimer = window.setTimeout(resolveOnce, maxWaitMs);
+
+      try {
+        observer = new MutationObserver(() => scheduleQuiet());
+        observer.observe(document.documentElement, {
+          attributes: true,
+          childList: true,
+          subtree: true,
+        });
+      } catch (e) {
+        resolveOnce();
+        return;
+      }
+
+      scheduleQuiet();
+    });
+  });
+};
+


### PR DESCRIPTION
## Issue: 
Visual Editor - Runtime crashes with Unhandled Errors due to multiple CSP violations. Reported here -> [slack](https://growthbookapp.slack.com/archives/C0AETU4KQ5N/p1772045470505359?thread_ts=1771540525.505819&cid=C0AETU4KQ5N) 

## What's Changed:
- Scoped CSP handling with severity + dedupe
- Updated CSP UI to show warning vs fatal in 
- Added hydration safety gate and deferred mutation replay.
- Delayed Visual Editor script injection until [window.load](app://-/index.html#) (if page not complete) 
- Added runtime crash containment (VisualEditorErrorBoundary), retry UI, GB_ERROR emission, idempotent mount, and remount watchdog.
- Non-fatal CSP warnings are now shown under a collapsible Issues section, collapsed by default.
- Fatal CSP issues / or other errors open the Issues section by default.

## Screenshot - After the change

<img width="715" height="892" alt="image" src="https://github.com/user-attachments/assets/106f29d8-00e0-45a6-a6d9-f0c3670c8cdf" />

<img width="715" height="892" alt="image" src="https://github.com/user-attachments/assets/6cb9c62a-608e-4f59-9cf5-4cc98a17526d" />
