### PR TITLE
Support holdouts in ui

### DIFF
--- a/src/app/components/ExperimentDetail.tsx
+++ b/src/app/components/ExperimentDetail.tsx
@@ -11,6 +11,7 @@ import {
   PiArrowSquareOut,
   PiCaretRightFill,
   PiFlagFill,
+  PiFlaskFill,
   PiInfo,
   PiLinkBold,
   PiDesktopFill,
@@ -26,6 +27,10 @@ import * as Accordion from "@radix-ui/react-accordion";
 import React, { CSSProperties, useEffect, useMemo, useState } from "react";
 import {
   ExperimentWithFeatures,
+  formatExperimentKey,
+  getExperimentDisplayName,
+  getHoldoutFeatureId,
+  holdoutIdFromFid,
   HEADER_H,
   LEFT_PERCENT,
 } from "./ExperimentsTab";
@@ -33,7 +38,7 @@ import useGlobalState from "@/app/hooks/useGlobalState";
 import { APP_ORIGIN, CLOUD_APP_ORIGIN } from "@/app/components/Settings";
 import useTabState from "@/app/hooks/useTabState";
 import { SelectedExperiment } from "@/app/components/ExperimentsTab";
-import { AutoExperimentVariation, isURLTargeted } from "@growthbook/growthbook";
+import { AutoExperimentVariation, FeatureDefinition, isURLTargeted } from "@growthbook/growthbook";
 import clsx from "clsx";
 import DebugLogger, { DebugLogAccordion } from "@/app/components/DebugLogger";
 import { TbEyeSearch } from "react-icons/tb";
@@ -90,6 +95,59 @@ export default function ExperimentDetail({
     "logEvents",
     undefined,
   );
+
+  const [features] = useTabState<Record<string, FeatureDefinition>>(
+    "features",
+    {},
+  );
+
+  const holdoutMembers = useMemo(() => {
+    const holdoutFid = selectedExperiment?.experiment
+      ? getHoldoutFeatureId(selectedExperiment.experiment)
+      : undefined;
+    if (!holdoutFid) return null;
+
+    const heldFeatures: string[] = [];
+    const heldExperiments: string[] = [];
+
+    for (const [fid, feature] of Object.entries(features)) {
+      const rules = feature.rules ?? [];
+      const rule0 = rules[0];
+      if (!rule0) continue;
+      const isHoldoutGate = rule0.parentConditions?.some(
+        (pc: { id?: string }) => pc.id === holdoutFid,
+      );
+      if (!isHoldoutGate) continue;
+
+      heldFeatures.push(fid);
+
+      for (let i = 1; i < rules.length; i++) {
+        const rule = rules[i] as any;
+        if (rule.variations && rule.key) {
+          heldExperiments.push(rule.key);
+        }
+      }
+    }
+
+    return heldFeatures.length || heldExperiments.length
+      ? { heldFeatures, heldExperiments }
+      : null;
+  }, [selectedExperiment?.experiment, features]);
+
+  // Detect if this experiment is itself under a holdout
+  const parentHoldout = useMemo(() => {
+    const expFeatures = selectedExperiment?.experiment?.features ?? [];
+    for (const fid of expFeatures) {
+      const rule0 = (features[fid]?.rules ?? [])[0] as any;
+      const holdoutFid = rule0?.parentConditions?.find(
+        (pc: { id?: string }) => pc.id?.startsWith("$holdout:"),
+      )?.id;
+      if (!holdoutFid) continue;
+      const holdoutExpKey = (features[holdoutFid]?.rules?.[0] as any)?.key;
+      if (holdoutExpKey) return { holdoutFid, holdoutExpKey };
+    }
+    return null;
+  }, [selectedExperiment?.experiment, features]);
 
   const [viewEvaluationSource, setViewEvaluationSource] = useState<
     string | undefined
@@ -196,7 +254,9 @@ export default function ExperimentDetail({
             <>
               <div className="flex items-start gap-2">
                 <h2 className="font-bold flex-1">
-                  {selectedExperiment?.experiment?.name || selectedEid}
+                  {selectedExperiment?.experiment
+                    ? getExperimentDisplayName(selectedExperiment.experiment)
+                    : selectedEid}
                 </h2>
                 <IconButton
                   size="3"
@@ -375,6 +435,69 @@ export default function ExperimentDetail({
             />
           ) : null}
 
+          {parentHoldout ? (
+            <div className="mt-3 mb-1">
+              <div className="label font-semibold">Holdout</div>
+              <Link
+                size="2"
+                role="button"
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setSelectedEid(parentHoldout.holdoutExpKey);
+                  setCurrentTab("experiments");
+                }}
+              >
+                <PiFlaskFill className="inline-block mr-1" size={12} />
+                {`Holdout Experiment (${holdoutIdFromFid(parentHoldout.holdoutFid)})`}
+              </Link>
+            </div>
+          ) : null}
+
+          {holdoutMembers ? (
+            <>
+              <div className="mt-4 mb-1 text-md font-semibold">
+                Held-out members
+              </div>
+              <div className="mb-4">
+                {holdoutMembers.heldFeatures.map((fid) => (
+                  <div key={fid}>
+                    <Link
+                      size="2"
+                      role="button"
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setSelectedFid(fid);
+                        setCurrentTab("features");
+                      }}
+                    >
+                      <PiFlagFill className="inline-block mr-1" size={12} />
+                      {fid}
+                    </Link>
+                  </div>
+                ))}
+                {holdoutMembers.heldExperiments.map((eid) => (
+                  <div key={eid}>
+                    <Link
+                      size="2"
+                      role="button"
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setSelectedEid(eid);
+                        setCurrentTab("experiments");
+                      }}
+                    >
+                      <PiFlaskFill className="inline-block mr-1" size={12} />
+                      {eid}
+                    </Link>
+                  </div>
+                ))}
+              </div>
+            </>
+          ) : null}
+
           <div className="mt-4 mb-1 text-md font-semibold">
             Implementation
             {(types?.redirect ? 1 : 0) +
@@ -410,7 +533,7 @@ export default function ExperimentDetail({
                   }}
                 >
                   <PiFlagFill className="inline-block mr-1" size={12} />
-                  {fid}
+                  {formatExperimentKey(fid)}
                 </Link>
               </div>
             ))}
@@ -604,9 +727,14 @@ export function getVariationSummary({
   const m = meta?.[i];
   const { urlRedirect } = (variation || {}) as AutoExperimentVariation;
 
+  const isHoldout = !!getHoldoutFeatureId(experiment);
+  const holdoutDefaults = ["Holdout", "Treatment"];
+
   let title = `Variation ${m?.key ?? i}`;
   if (m?.name) {
     title = m.name;
+  } else if (isHoldout && holdoutDefaults[i] !== undefined) {
+    title = holdoutDefaults[i];
   } else if (urlRedirect) {
     title += `(${urlRedirect})`;
   }

--- a/src/app/components/ExperimentsTab.tsx
+++ b/src/app/components/ExperimentsTab.tsx
@@ -291,6 +291,7 @@ export default function ExperimentsTab() {
                 <div
                   className="title line-clamp-1 pl-2.5 pr-8"
                   style={{ width: fullWidthListView ? col1 : undefined }}
+                  title={getExperimentDisplayName(experiment)}
                 >
                   <FeatureExperimentStatusIcon
                     evaluated={pageEvaluatedExperiments.has(eid)}
@@ -303,7 +304,7 @@ export default function ExperimentsTab() {
                       size={12}
                     />
                   ) : null}
-                  {eid}
+                  {getExperimentDisplayName(experiment)}
                 </div>
                 <div
                   className={clsx("flex items-center flex-shrink-0 text-sm", {
@@ -477,4 +478,36 @@ export function getFeatureExperiments(
     }
   }
   return experiments;
+}
+
+// Extracts the holdout ID from a $holdout:<id> feature ID, or returns undefined
+export function holdoutIdFromFid(fid: string): string | undefined {
+  const match = fid.match(/^\$holdout:(.+)$/);
+  return match ? match[1] : undefined;
+}
+
+// Used to prettify $holdout:<id> feature IDs (feature list, detail header, Implementation link)
+export function formatExperimentKey(key: string): string {
+  const holdoutId = holdoutIdFromFid(key);
+  if (holdoutId) {
+    return `Holdout generated feature (${holdoutId})`;
+  }
+  return key;
+}
+
+export function getHoldoutFeatureId(
+  experiment: ExperimentWithFeatures,
+): string | undefined {
+  return experiment.features?.find((f) => f.startsWith("$holdout:"));
+}
+
+export function getExperimentDisplayName(
+  experiment: ExperimentWithFeatures,
+): string {
+  if (experiment.name) return experiment.name;
+  const holdoutFid = getHoldoutFeatureId(experiment);
+  if (holdoutFid) {
+    return `Holdout (${holdoutIdFromFid(holdoutFid)})`;
+  }
+  return experiment.key;
 }

--- a/src/app/components/FeatureDetail.tsx
+++ b/src/app/components/FeatureDetail.tsx
@@ -18,9 +18,11 @@ import {
   PiCheck,
   PiCheckCircleBold,
   PiCircleFill,
+  PiFlaskFill,
   PiFunnelBold,
   PiInfo,
   PiTimerBold,
+  PiWarningFill,
   PiXBold,
 } from "react-icons/pi";
 import EditableValueField from "@/app/components/EditableValueField";
@@ -32,6 +34,7 @@ import Rule, {
 import * as Accordion from "@radix-ui/react-accordion";
 import React, { useEffect, useMemo, useState } from "react";
 import { HEADER_H, LEFT_PERCENT, SelectedFeature } from "./FeaturesTab";
+import { formatExperimentKey, holdoutIdFromFid } from "@/app/components/ExperimentsTab";
 import useGlobalState from "@/app/hooks/useGlobalState";
 import { APP_ORIGIN, CLOUD_APP_ORIGIN } from "@/app/components/Settings";
 import useTabState, { getActiveTabId } from "@/app/hooks/useTabState";
@@ -41,7 +44,7 @@ import useApi from "@/app/hooks/useApi";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { LogUnionWithSource } from "@/app/utils/logs";
-import { FeatureResult, Result } from "@growthbook/growthbook";
+import { FeatureDefinition, FeatureResult, Result } from "@growthbook/growthbook";
 import clsx from "clsx";
 
 export type ApiFeatureWithRevisions = {
@@ -138,6 +141,38 @@ export default function FeatureDetail({
     "logEvents",
     undefined,
   );
+
+  const [features] = useTabState<Record<string, FeatureDefinition>>(
+    "features",
+    {},
+  );
+
+  // Detect if this feature is held-out: rules[0] has a parentCondition referencing a $holdout: fid
+  const holdoutGateFid = useMemo(() => {
+    const rules = selectedFeature?.feature?.rules ?? [];
+    const rule0 = rules[0] as any;
+    return (
+      rule0?.parentConditions?.find((pc: { id?: string }) =>
+        pc.id?.startsWith("$holdout:"),
+      )?.id ?? null
+    );
+  }, [selectedFid, selectedFeature?.feature?.rules]);
+
+  // The holdout experiment key lives on the holdout feature's first rule
+  const holdoutExpKey = useMemo(() => {
+    if (!holdoutGateFid) return null;
+    const holdoutFeature = features[holdoutGateFid];
+    return (holdoutFeature?.rules?.[0] as any)?.key ?? null;
+  }, [holdoutGateFid, features]);
+
+  const [selectedEid, setSelectedEid] = useTabState<string | undefined>(
+    "selectedEid",
+    undefined,
+  );
+  const [selectedChangeId, setSelectedChangeId] = useTabState<
+    string | undefined
+  >("selectedChangeId", undefined);
+  const [currentTab, setCurrentTab] = useTabState("currentTab", "features");
 
   const [viewEvaluationSource, setViewEvaluationSource] = useState<
     string | undefined
@@ -421,7 +456,7 @@ export default function FeatureDetail({
           {selectedFid && (
             <>
               <div className="flex items-start gap-2">
-                <h2 className="font-bold flex-1">{selectedFid}</h2>
+                <h2 className="font-bold flex-1">{formatExperimentKey(selectedFid)}</h2>
                 <IconButton
                   size="3"
                   variant="ghost"
@@ -435,22 +470,36 @@ export default function FeatureDetail({
                   <PiXBold />
                 </IconButton>
               </div>
-              <Link
-                size="2"
-                href={`${appOrigin}/features/${selectedFid}`}
-                target="_blank"
-              >
-                GrowthBook
-                <PiArrowSquareOut
-                  size={16}
-                  className="inline-block mb-1 ml-0.5"
-                />
-              </Link>
+              {!selectedFid?.startsWith("$holdout:") && (
+                <Link
+                  size="2"
+                  href={`${appOrigin}/features/${selectedFid}`}
+                  target="_blank"
+                >
+                  GrowthBook
+                  <PiArrowSquareOut
+                    size={16}
+                    className="inline-block mb-1 ml-0.5"
+                  />
+                </Link>
+              )}
             </>
           )}
         </div>
 
         <div className="content">
+          {selectedFid?.startsWith("$holdout:") ? (
+            <Callout.Root color="amber" size="1" className="mt-1 mb-3">
+              <Callout.Icon>
+                <PiWarningFill />
+              </Callout.Icon>
+              <Callout.Text>
+                This is a generated feature flag used for holdout
+                implementation.
+              </Callout.Text>
+            </Callout.Root>
+          ) : null}
+
           {featureMetaData?.feature?.description ? (
             <div>
               <div className="label font-semibold mb-1">Description</div>
@@ -600,6 +649,34 @@ export default function FeatureDetail({
               </>
             ) : null}
           </div>
+
+          {holdoutGateFid ? (
+            <div className="mt-6 mb-4">
+              <div className="text-md font-semibold mb-1">Holdout</div>
+              <div>
+                {holdoutExpKey ? (
+                  <Link
+                    size="2"
+                    role="button"
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setSelectedEid(holdoutExpKey);
+                      setSelectedChangeId(undefined);
+                      setCurrentTab("experiments");
+                    }}
+                  >
+                    <PiFlaskFill className="inline-block mr-1" size={12} />
+                    {`Holdout Experiment (${holdoutIdFromFid(holdoutGateFid)})`}
+                  </Link>
+                ) : (
+                  <span className="text-sm">
+                    {formatExperimentKey(holdoutGateFid)}
+                  </span>
+                )}
+              </div>
+            </div>
+          ) : null}
 
           <div className="mt-6 mb-2 py-1 border-b border-gray-a6">
             <div className="flex justify-between items-end text-md font-semibold">

--- a/src/app/components/FeaturesTab.tsx
+++ b/src/app/components/FeaturesTab.tsx
@@ -25,6 +25,7 @@ import FeatureExperimentStatusIcon from "@/app/components/FeatureExperimentStatu
 import { useResponsiveContext } from "../hooks/useResponsive";
 import { TbEyeSearch } from "react-icons/tb";
 import { LogUnionWithSource } from "@/app/utils/logs";
+import { formatExperimentKey } from "@/app/components/ExperimentsTab";
 
 export type FeatureDefinitionWithId = FeatureDefinition & {
   id: string;
@@ -285,6 +286,7 @@ export default function FeaturesTab() {
                       "top-[13px]": fullWidthListView,
                     })}
                     style={{ width: fullWidthListView ? col1 : undefined }}
+                    title={formatExperimentKey(fid)}
                   >
                     <FeatureExperimentStatusIcon
                       evaluated={pageEvaluatedFeatures.has(fid)}
@@ -307,7 +309,7 @@ export default function FeaturesTab() {
                         </span>
                       </Tooltip>
                     ) : null}
-                    {fid}
+                    {formatExperimentKey(fid)}
                   </div>
                 </div>
                 {fullWidthListView && (

--- a/src/app/components/Rule.tsx
+++ b/src/app/components/Rule.tsx
@@ -23,6 +23,7 @@ import {
 import { EvaluatedFeature } from "@/app/hooks/useGBSandboxEval";
 import DebugLogger from "@/app/components/DebugLogger";
 import useGlobalState from "@/app/hooks/useGlobalState";
+import { formatExperimentKey, holdoutIdFromFid } from "@/app/components/ExperimentsTab";
 import { isDark, Theme } from "@/app";
 
 type RuleType = "force" | "rollout" | "experiment" | "prerequisite" | "safe-rollout";
@@ -165,7 +166,9 @@ export default function Rule({
                 }}
               >
                 <PiFlaskFill className="inline-block mr-0.5" size={12} />
-                {key}
+                {holdoutIdFromFid(fid)
+                  ? `Holdout Experiment (${holdoutIdFromFid(fid)})`
+                  : key}
               </Link>
             )}
           </div>
@@ -473,7 +476,7 @@ export function ConditionDisplay({
                 }}
               >
                 <PiFlagFill className="inline-block mr-0.5" size={12} />
-                {cond.field}
+                {formatExperimentKey(cond.field)}
               </Link>
             ) : (
               cond.field


### PR DESCRIPTION
Improve the UI around holdout experiments, generated holdout features, and surfacing holdout membership.

<img width="707" height="559" alt="image" src="https://github.com/user-attachments/assets/bb40434c-0091-4a8a-b4d5-7ae27efe6a3f" />

<img width="709" height="559" alt="image" src="https://github.com/user-attachments/assets/dff7352c-64c9-4dd3-ab32-a56d23045e43" />
