### PR TITLE
Fix payload patch merging for arrays

### DIFF
--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -11,6 +11,8 @@ import type {
 import type { ErrorMessage, SDKHealthCheckResult } from "devtools";
 import { Attributes } from "@growthbook/growthbook";
 
+import { mergePayloadPatch } from "./payload";
+
 type LogUnionWithSource = LogUnion & { source?: string; clientKey?: string };
 
 type StateObj = {
@@ -302,22 +304,11 @@ function setPayload(data: FeatureApiResponse) {
 function patchPayload(data: FeatureApiResponse) {
   if (!data) return;
   onGrowthBookLoad((gb) => {
-    const payload = gb.getDecryptedPayload?.() || {
+    const currentPayload = gb.getDecryptedPayload?.() || {
       features: gb.getFeatures?.(),
       experiments: gb.getExperiments?.(),
     };
-    Object.keys(data).forEach((key) => {
-      const k = key as keyof FeatureApiResponse;
-      if (!payload[k]) {
-        // @ts-ignore
-        payload[k] = data[k];
-      } else {
-        if (typeof payload[k] === "object") {
-          // @ts-ignore
-          payload[k] = { ...payload[k], ...data[k] };
-        }
-      }
-    });
+    const payload = mergePayloadPatch(currentPayload, data);
 
     if (gb.setPayload) {
       gb.setPayload(payload);

--- a/src/content_script/payload.test.ts
+++ b/src/content_script/payload.test.ts
@@ -1,0 +1,61 @@
+import type { FeatureApiResponse } from "@growthbook/growthbook";
+
+import { mergePayloadPatch } from "./payload";
+
+describe("mergePayloadPatch", () => {
+  it("replaces arrays instead of object-spreading them into objects", () => {
+    const payload = mergePayloadPatch(
+      {
+        features: {},
+        experiments: [],
+      },
+      {
+        experiments: [],
+      },
+    );
+
+    expect(Array.isArray(payload.experiments)).toBe(true);
+    expect(payload.experiments).toEqual([]);
+  });
+
+  it("keeps shallow object merge behavior for features", () => {
+    const payload = mergePayloadPatch(
+      {
+        features: {
+          existing: {
+            defaultValue: true,
+          },
+        },
+      },
+      {
+        features: {
+          incoming: {
+            defaultValue: false,
+          },
+        },
+      },
+    );
+
+    expect(payload.features).toEqual({
+      existing: {
+        defaultValue: true,
+      },
+      incoming: {
+        defaultValue: false,
+      },
+    });
+  });
+
+  it("replaces scalar payload fields", () => {
+    const payload = mergePayloadPatch(
+      {
+        dateUpdated: "old",
+      },
+      {
+        dateUpdated: "new",
+      } as FeatureApiResponse,
+    );
+
+    expect(payload.dateUpdated).toBe("new");
+  });
+});

--- a/src/content_script/payload.ts
+++ b/src/content_script/payload.ts
@@ -1,0 +1,35 @@
+import type { FeatureApiResponse } from "@growthbook/growthbook";
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function mergePayloadPatch(
+  currentPayload: FeatureApiResponse,
+  patch: FeatureApiResponse,
+): FeatureApiResponse {
+  const payload = { ...currentPayload };
+
+  Object.keys(patch).forEach((key) => {
+    const k = key as keyof FeatureApiResponse;
+    const currentValue = payload[k];
+    const patchValue = patch[k];
+
+    if (patchValue === undefined) return;
+
+    if (Array.isArray(patchValue)) {
+      // Auto experiments are arrays. Object-spreading arrays corrupts [] into {}.
+      payload[k] = patchValue as never;
+      return;
+    }
+
+    if (isObjectRecord(currentValue) && isObjectRecord(patchValue)) {
+      payload[k] = { ...currentValue, ...patchValue } as never;
+      return;
+    }
+
+    payload[k] = patchValue as never;
+  });
+
+  return payload;
+}


### PR DESCRIPTION
This is a fix for #109. It was fully written by Codex. I looked at the code and it looks sensible, but I haven't dug deep in the codebase to verify it.