### PR TITLE
Update trackingCallback with user argument

### DIFF
--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -7,10 +7,18 @@ import type {
   Options,
   Result,
   TrackingCallback,
+  TrackingData,
   UserContext,
 } from "@growthbook/growthbook";
 import type { ErrorMessage, SDKHealthCheckResult } from "devtools";
 import { Attributes } from "@growthbook/growthbook";
+
+
+type TrackingCallbackWithUser = (
+  experiment: Experiment<any>,
+  result: Result<any>,
+  user?: UserContext,
+) => void;
 
 type LogUnionWithSource = LogUnion & { source?: string; clientKey?: string };
 
@@ -459,7 +467,7 @@ function subscribeToSdkChanges(
     const patchedCallBack = (
       experiment: Experiment<any>,
       result: Result<any>,
-      user: UserContext
+      user?: UserContext,
     ) => {
       if (!hasSdkLogSupport) {
         gb.logs!.push({
@@ -472,10 +480,10 @@ function subscribeToSdkChanges(
       if ("isNoopCallback" in callback && callback.isNoopCallback) {
         gb.setDeferredTrackingCalls?.([
           ...gb.getDeferredTrackingCalls(),
-          { experiment, result, user },
+          { experiment, result, user } as TrackingData,
         ]);
       }
-      (callback(experiment, result, user);
+      (callback as TrackingCallbackWithUser)(experiment, result, user);
     };
     if ("isNoopCallback" in callback && callback.isNoopCallback) {
       patchedCallBack.isNoopCallback = true;

--- a/src/content_script/embed_script.ts
+++ b/src/content_script/embed_script.ts
@@ -7,6 +7,7 @@ import type {
   Options,
   Result,
   TrackingCallback,
+  UserContext,
 } from "@growthbook/growthbook";
 import type { ErrorMessage, SDKHealthCheckResult } from "devtools";
 import { Attributes } from "@growthbook/growthbook";
@@ -458,6 +459,7 @@ function subscribeToSdkChanges(
     const patchedCallBack = (
       experiment: Experiment<any>,
       result: Result<any>,
+      user: UserContext
     ) => {
       if (!hasSdkLogSupport) {
         gb.logs!.push({
@@ -470,10 +472,10 @@ function subscribeToSdkChanges(
       if ("isNoopCallback" in callback && callback.isNoopCallback) {
         gb.setDeferredTrackingCalls?.([
           ...gb.getDeferredTrackingCalls(),
-          { experiment, result },
+          { experiment, result, user },
         ]);
       }
-      callback(experiment, result);
+      (callback(experiment, result, user);
     };
     if ("isNoopCallback" in callback && callback.isNoopCallback) {
       patchedCallBack.isNoopCallback = true;


### PR DESCRIPTION
**Forward `user` arg through the patched tracking callback**

The content script's `setTrackingCallback` patch dropped the callback's third arg, so consumers got `user === undefined`. The SDK calls tracking callbacks with `(experiment, result, user)`, where `user` is the attribute snapshot at evaluation time.

This updates the wrapper in `embed_script.ts` to accept and forward an optional `user?: UserContext`, and to include it in the object pushed to `setDeferredTrackingCalls` (`{ experiment, result, user }`). `user` is optional throughout, so it flows through safely as `undefined` when the page SDK doesn't supply one. `isNoopCallback` / `originalParams` handling is unchanged.

Preserving this exact arg matters because reading live attributes instead would drift for deferred tracking calls.

Note: the pinned SDK (`1.6.5`) predates the 3-arg signature, so a small local `TrackingCallbackWithUser` type and an `as TrackingData` cast are used to compile; both can be dropped once the SDK is bumped.